### PR TITLE
Fix callbacks

### DIFF
--- a/src/main/java/org/dcsa/service/impl/EventServiceImpl.java
+++ b/src/main/java/org/dcsa/service/impl/EventServiceImpl.java
@@ -81,22 +81,22 @@ public class EventServiceImpl extends BaseServiceImpl<EventRepository, Event, UU
             case "SHIPMENT":
                 returnEvent = (Mono<T>) shipmentEventService.save((ShipmentEvent) event);
                 callbackUrls = eventSubscriptionRepository.findSubscriptionsByFilters(event.getEventType(), null);
-                new CallbackHandler(callbackUrls, (ShipmentEvent) event).start();
+                returnEvent.doOnNext(it->new CallbackHandler(callbackUrls, (ShipmentEvent) it).start()).subscribe();
                 break;
             case "TRANSPORT":
                 returnEvent = (Mono<T>) transportEventService.save((TransportEvent) event);
                 callbackUrls = eventSubscriptionRepository.findSubscriptionsByFilters(event.getEventType(), null);
-                new CallbackHandler(callbackUrls, (TransportEvent) event).start();
+                returnEvent.doOnNext(it->new CallbackHandler(callbackUrls, (TransportEvent) it).start()).subscribe();
                 break;
             case "TRANSPORTEQUIPMENT":
                 returnEvent = (Mono<T>) transportEquipmentEventService.save((TransportEquipmentEvent) event);
                 callbackUrls = eventSubscriptionRepository.findSubscriptionsByFilters(event.getEventType(), ((TransportEquipmentEvent) event).getEquipmentReference());
-                new CallbackHandler(callbackUrls, (TransportEquipmentEvent) event).start();
+                returnEvent.doOnNext(it->new CallbackHandler(callbackUrls, (TransportEquipmentEvent) it).start()).subscribe();
                 break;
             case "EQUIPMENT":
                 returnEvent = (Mono<T>) equipmentEventService.save((EquipmentEvent) event);
                 callbackUrls = eventSubscriptionRepository.findSubscriptionsByFilters(event.getEventType(), ((EquipmentEvent) event).getEquipmentReference());
-                new CallbackHandler(callbackUrls, (EquipmentEvent) event).start();
+                returnEvent.doOnNext(it->new CallbackHandler(callbackUrls, (EquipmentEvent) it).start()).subscribe();
                 break;
             default:
                 throw new IllegalStateException("Unexpected value: " + event.getEventType());


### PR DESCRIPTION
Callback events were sent back with a null ID, when they were created
without one.

This fix returns the event generated by the database, with the database
generated ID.