### PR TITLE
Rewriting sql-injection prevention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>11</java.version>
 		<rest-assured.version>4.3.1</rest-assured.version>
         <groovy.version>3.0.2</groovy.version>
-		<revision>0.5.0</revision>
+		<revision>0.6.0</revision>
 		<sha1/>
 		<changelist/>
 	</properties>

--- a/src/main/java/org/dcsa/core/extendedrequest/FilterItem.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/FilterItem.java
@@ -6,29 +6,46 @@ import lombok.Getter;
 public class FilterItem {
     private final String fieldName;
     private final Class<?> clazz;
-    private final String fieldValue;
+    private final Object fieldValue;
     private final boolean exactMatch;
     private final boolean orGroup;
     private final boolean stringValue;
+    private final boolean ignoreCase;
+    private final int bindNumber;
 
-    public FilterItem(String fieldName, Class<?> clazz, String fieldValue, boolean exactMatch, boolean orGroup, boolean stringValue) {
+    public FilterItem(String fieldName, Class<?> clazz, Object fieldValue, boolean exactMatch, boolean orGroup, boolean stringValue, boolean ignoreCase, int bindNumber) {
         this.fieldName = fieldName;
         this.clazz = clazz;
         this.fieldValue = fieldValue;
         this.exactMatch = exactMatch;
         this.orGroup = orGroup;
         this.stringValue = stringValue;
+        this.ignoreCase = ignoreCase;
+        this.bindNumber = bindNumber;
     }
 
-    public static FilterItem addStringFilter(String fieldName, Class<?> clazz, String value) {
-        return new FilterItem(fieldName, clazz, value, false, false, true);
+    public String getBindName() {
+        return fieldName + bindNumber;
+    }
+    public Object getQueryFieldValue() {
+        if (exactMatch) {
+            return fieldValue;
+        } else {
+            return "%" + fieldValue + "%";
+        }
+    }
+    public boolean doBind() {
+        return true;
+    }
+    public static FilterItem addStringFilter(String fieldName, Class<?> clazz, String value, boolean ignoreCase, int bindNumber) {
+        return new FilterItem(fieldName, clazz, value, false, false, true, ignoreCase, bindNumber);
     }
 
-    public static FilterItem addExactFilter(String fieldName, Class<?> clazz, String value, boolean stringValue) {
-        return new FilterItem(fieldName, clazz, value, true, false, stringValue);
+    public static FilterItem addExactFilter(String fieldName, Class<?> clazz, Object value, boolean stringValue, int bindNumber) {
+        return new FilterItem(fieldName, clazz, value, true, false, stringValue, false, bindNumber);
     }
 
-    public static FilterItem addOrGroupFilter(String fieldName, Class<?> clazz, String value, boolean exactMatch) {
-        return new FilterItem(fieldName, clazz, value, exactMatch, true, true);
+    public static FilterItem addOrGroupFilter(String fieldName, Class<?> clazz, String value, boolean exactMatch, int bindNumber) {
+        return new FilterItem(fieldName, clazz, value, exactMatch, true, true, false, bindNumber);
     }
 }

--- a/src/main/java/org/dcsa/core/model/ModelClass.java
+++ b/src/main/java/org/dcsa/core/model/ModelClass.java
@@ -4,9 +4,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Field;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ModelClass {
     Class<?> value();
+    String fieldName() default "";
 }

--- a/src/main/java/org/dcsa/core/repository/ExtendedRepositoryImpl.java
+++ b/src/main/java/org/dcsa/core/repository/ExtendedRepositoryImpl.java
@@ -26,13 +26,12 @@ public class ExtendedRepositoryImpl<T, I> extends SimpleR2dbcRepository<T, I> im
     }
 
     public Mono<Integer> countAllExtended(final ExtendedRequest<T> extendedRequest) {
-        return databaseClient
-                .execute(extendedRequest.getCountQuery()).as(Integer.class).fetch().first();
+        return extendedRequest.getCount(databaseClient)
+                .as(Integer.class).fetch().first();
     }
 
     public Flux<T> findAllExtended(final ExtendedRequest<T> extendedRequest) {
-        return databaseClient
-                .execute(extendedRequest.getQuery())
+        return extendedRequest.getFindAll(databaseClient)
                 .map((row, meta) -> {
                     // Get a new instance of the Object to return
                     T object = extendedRequest.getModelClassInstance(row, meta);


### PR DESCRIPTION
Bump Core version to 0.6.0
Rewriting of how variables are added to the queries. In order to prevent sql injection bindings are used.
Case can be ignored when filtering
Improved ReflectUtils class to also use the ModelClass annotation when using Combined results (results from database JOIN)