### PR TITLE
Insert prehooks to be able to chack objects before making CRUD operat…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>11</java.version>
 		<rest-assured.version>4.3.1</rest-assured.version>
         <groovy.version>3.0.2</groovy.version>
-		<revision>0.7.2</revision>
+		<revision>0.7.3</revision>
 		<sha1/>
 		<changelist/>
 	</properties>

--- a/src/main/java/org/dcsa/core/service/impl/BaseServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/BaseServiceImpl.java
@@ -3,6 +3,7 @@ package org.dcsa.core.service.impl;
 import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.model.GetId;
 import org.dcsa.core.service.BaseService;
+import org.dcsa.core.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
@@ -29,29 +30,91 @@ public abstract class BaseServiceImpl<R extends R2dbcRepository<T, I>, T extends
 
     @Override
     public Mono<T> create(T t) {
-        return getRepository().save(t);
+        return Mono.just(t)
+                .flatMap(this::preCreateHook)
+                .flatMap(this::save);
     }
 
     @Override
     public Mono<T> save(T t) {
-        return getRepository().save(t);
+        return Mono.just(t)
+                .flatMap(this::preSaveHook)
+                .flatMap(getRepository()::save);
     }
 
     @Override
-    public Mono<T> update(final T t) {
-        return findById(t.getId())
-                .flatMap(d -> getRepository().save(t));
+    public Mono<T> update(final T update) {
+        return findById(update.getId())
+                .flatMap(current -> this.preUpdateHook(current, update))
+                .flatMap(this::save);
     }
 
     @Override
     public Mono<Void> deleteById(I id) {
-        return findById(id)
+        return this.findById(id)
+                .flatMap(this::preDeleteHook)
                 .flatMap(getRepository()::delete);
     }
 
     @Override
     public Mono<Void> delete(T t) {
         return findById(t.getId())
+                .flatMap(this::preDeleteHook)
                 .flatMap(getRepository()::delete);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save the model instance.
+     *
+     * @param t The instance about to saved.
+     * @return The method must return its argument (possibly modified) as Mono, which will be saved
+     *         or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preSaveHook(T t) {
+        return Mono.just(t);
+    }
+
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save a newly created model instance.
+     *
+     * This will be run <i>before</i> the {@link #preSaveHook(GetId)} and can contain create specific logic
+     * (if any).
+     *
+     * @param t The instance about to saved.
+     * @return The method must return its argument (possibly modified) as Mono, which will be saved
+     *         or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preCreateHook(T t) {
+        return Mono.just(t);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save an updated model instance.
+     *
+     * This will be run <i>before</i> the {@link #preSaveHook(GetId)} and can contain update specific logic
+     * (if any).
+     *
+     * @param current The copy of the instance in the database.
+     * @param update The instance provided externally with the changes.
+     * @return The method must return exactly one of the arguments (possibly modified) as Mono or an error
+     * (e.g. via {@link Mono#error(Throwable)}).  The return value is what will be saved (if it is not an
+     * error Mono).
+     */
+    protected Mono<T> preUpdateHook(T current, T update) {
+        return Mono.just(update);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to delete a model instance.
+     *
+     * The hook can prevent the removal by returning an error Mono (e.g. via {@link Mono#error(Throwable)}) or
+     * do service specific clean up related to the instance.
+     *
+     * @param t The instance about to be deleted
+     * @return The method must return the argument as a Mono or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preDeleteHook(T t) {
+        return Mono.just(t);
     }
 }


### PR DESCRIPTION
Insert a prehook in: Create, Update and Delete operations in order to check/validate the object before creating, Saving or deleting it
This is needed for eBL in order to validate that a given operation is allowed during a specific documentState