### PR TITLE
Add missing `@EqualsAndHashCode` annotation on AuditBase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>11</java.version>
 		<rest-assured.version>4.3.1</rest-assured.version>
         <groovy.version>3.0.2</groovy.version>
-		<revision>0.7.6</revision>
+		<revision>0.7.7</revision>
 		<sha1/>
 		<changelist/>
 	</properties>

--- a/src/main/java/org/dcsa/core/model/AuditBase.java
+++ b/src/main/java/org/dcsa/core/model/AuditBase.java
@@ -1,6 +1,7 @@
 package org.dcsa.core.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.EqualsAndHashCode;
 import org.springframework.data.annotation.*;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.relational.core.mapping.Column;
@@ -8,6 +9,7 @@ import reactor.util.annotation.NonNull;
 
 import java.util.Optional;
 
+@EqualsAndHashCode
 public abstract class AuditBase implements AuditorAware<String> {
 
     @NonNull


### PR DESCRIPTION
Without it, `equals()` always returns false for subclasses.