### PR TITLE
Improve support for non-repository backed services and related controllers (e.g. TO)

### DIFF
--- a/.github/workflows/runTNTTests.yml
+++ b/.github/workflows/runTNTTests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           repository: dcsaorg/DCSA-TNT
-          ref: extended-request-rewrite
+          ref: master
           path: DCSA-TNT
           token: ${{ secrets.REPO_ACCESS_PAT }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>11</java.version>
 		<rest-assured.version>4.3.1</rest-assured.version>
         <groovy.version>3.0.2</groovy.version>
-		<revision>0.8.0</revision>
+		<revision>0.8.1</revision>
 		<sha1/>
 		<changelist/>
 	</properties>

--- a/src/main/java/org/dcsa/core/controller/BaseController.java
+++ b/src/main/java/org/dcsa/core/controller/BaseController.java
@@ -3,8 +3,9 @@ package org.dcsa.core.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.core.exception.*;
 import org.dcsa.core.service.BaseService;
-import org.springframework.data.r2dbc.BadSqlGrammarException;
 import org.springframework.http.HttpStatus;
+import org.springframework.r2dbc.BadSqlGrammarException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ServerWebInputException;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,8 @@ public abstract class BaseController<S extends BaseService<T, I>, T, I> {
         return getService().findById(id);
     }
 
-    @PostMapping()
+    @Transactional
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<T> create(@Valid @RequestBody T t) {
         S s = getService();
@@ -33,6 +35,7 @@ public abstract class BaseController<S extends BaseService<T, I>, T, I> {
         return s.create(t);
     }
 
+    @Transactional
     @PutMapping("{id}")
     @ResponseStatus(HttpStatus.OK)
     public Mono<T> update(@PathVariable I id, @Valid @RequestBody T t) {
@@ -43,7 +46,8 @@ public abstract class BaseController<S extends BaseService<T, I>, T, I> {
         return s.update(t);
     }
 
-    @DeleteMapping()
+    @Transactional
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> delete(@RequestBody T t) {
         S s = getService();
@@ -53,6 +57,7 @@ public abstract class BaseController<S extends BaseService<T, I>, T, I> {
         return s.delete(t);
     }
 
+    @Transactional
     @DeleteMapping("{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> deleteById(@PathVariable I id) {

--- a/src/main/java/org/dcsa/core/service/BaseService.java
+++ b/src/main/java/org/dcsa/core/service/BaseService.java
@@ -7,7 +7,6 @@ public interface BaseService<T, I> {
     Flux<T> findAll();
     Mono<T> findById(I id);
     Mono<T> create(T t);
-    Mono<T> save(T t);
     Mono<T> update(T t);
     Mono<Void> deleteById(I id);
     Mono<Void> delete(T t);

--- a/src/main/java/org/dcsa/core/service/impl/BaseRepositoryBackedServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/BaseRepositoryBackedServiceImpl.java
@@ -1,0 +1,113 @@
+package org.dcsa.core.service.impl;
+
+import org.dcsa.core.exception.NotFoundException;
+import org.dcsa.core.service.BaseService;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public abstract class BaseRepositoryBackedServiceImpl<R extends R2dbcRepository<T, I>, T, I> extends BaseServiceImpl<T, I> {
+
+    public abstract R getRepository();
+    public abstract I getIdOfEntity(T entity);
+
+    @Override
+    public Flux<T> findAll() {
+        return getRepository().findAll();
+    }
+
+    @Override
+    public Mono<T> findById(final I id) {
+        return getRepository().findById(id)
+                .switchIfEmpty(Mono.error(new NotFoundException("No " + getType() + " was found with id: " + id)));
+    }
+
+    @Override
+    public Mono<T> create(T t) {
+        return Mono.just(t)
+                .flatMap(this::preCreateHook)
+                .flatMap(this::save);
+    }
+
+    protected Mono<T> save(T t) {
+        return Mono.just(t)
+                .flatMap(this::preSaveHook)
+                .flatMap(getRepository()::save);
+    }
+
+    @Override
+    public Mono<T> update(final T update) {
+        return findById(getIdOfEntity(update))
+                .flatMap(current -> this.preUpdateHook(current, update))
+                .flatMap(this::save);
+    }
+
+    @Override
+    public Mono<Void> deleteById(I id) {
+        return this.findById(id)
+                .flatMap(this::preDeleteHook)
+                .flatMap(getRepository()::delete);
+    }
+
+    @Override
+    public Mono<Void> delete(T t) {
+        return findById(getIdOfEntity(t))
+                .flatMap(this::preDeleteHook)
+                .flatMap(getRepository()::delete);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save the model instance.
+     *
+     * @param t The instance about to saved.
+     * @return The method must return its argument (possibly modified) as Mono, which will be saved
+     *         or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preSaveHook(T t) {
+        return Mono.just(t);
+    }
+
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save a newly created model instance.
+     *
+     * This will be run <i>before</i> the {@link #preSaveHook(Object)} and can contain create specific logic
+     * (if any).
+     *
+     * @param t The instance about to saved.
+     * @return The method must return its argument (possibly modified) as Mono, which will be saved
+     *         or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preCreateHook(T t) {
+        return Mono.just(t);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to save an updated model instance.
+     *
+     * This will be run <i>before</i> the {@link #preSaveHook(Object)} and can contain update specific logic
+     * (if any).
+     *
+     * @param current The copy of the instance in the database.
+     * @param update The instance provided externally with the changes.
+     * @return The method must return exactly one of the arguments (possibly modified) as Mono or an error
+     * (e.g. via {@link Mono#error(Throwable)}).  The return value is what will be saved (if it is not an
+     * error Mono).
+     */
+    protected Mono<T> preUpdateHook(T current, T update) {
+        return Mono.just(update);
+    }
+
+    /**
+     * A hook for subclasses that need a hook before *any* attempt to delete a model instance.
+     *
+     * The hook can prevent the removal by returning an error Mono (e.g. via {@link Mono#error(Throwable)}) or
+     * do service specific clean up related to the instance.
+     *
+     * @param t The instance about to be deleted
+     * @return The method must return the argument as a Mono or an error (e.g. via {@link Mono#error(Throwable)}).
+     */
+    protected Mono<T> preDeleteHook(T t) {
+        return Mono.just(t);
+    }
+}

--- a/src/main/java/org/dcsa/core/service/impl/BaseServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/BaseServiceImpl.java
@@ -1,115 +1,20 @@
 package org.dcsa.core.service.impl;
 
-import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.service.BaseService;
-import org.springframework.data.r2dbc.repository.R2dbcRepository;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+import org.dcsa.core.util.ReflectUtility;
 
-public abstract class BaseServiceImpl<R extends R2dbcRepository<T, I>, T, I> implements BaseService<T, I> {
+public abstract class BaseServiceImpl<T, I> implements BaseService<T, I> {
 
-    public abstract R getRepository();
-    public abstract String getType();
-    public abstract I getIdOfEntity(T entity);
+    private transient Class<T> modelClass;
 
-    @Override
-    public Flux<T> findAll() {
-        return getRepository().findAll();
+    protected String getType() {
+        return getModelClass().getSimpleName();
     }
 
-    @Override
-    public Mono<T> findById(final I id) {
-        return getRepository().findById(id)
-                .switchIfEmpty(Mono.error(new NotFoundException("No " + getType() + " was found with id: " + id)));
-    }
-
-    @Override
-    public Mono<T> create(T t) {
-        return Mono.just(t)
-                .flatMap(this::preCreateHook)
-                .flatMap(this::save);
-    }
-
-    @Override
-    public Mono<T> save(T t) {
-        return Mono.just(t)
-                .flatMap(this::preSaveHook)
-                .flatMap(getRepository()::save);
-    }
-
-    @Override
-    public Mono<T> update(final T update) {
-        return findById(getIdOfEntity(update))
-                .flatMap(current -> this.preUpdateHook(current, update))
-                .flatMap(this::save);
-    }
-
-    @Override
-    public Mono<Void> deleteById(I id) {
-        return this.findById(id)
-                .flatMap(this::preDeleteHook)
-                .flatMap(getRepository()::delete);
-    }
-
-    @Override
-    public Mono<Void> delete(T t) {
-        return findById(getIdOfEntity(t))
-                .flatMap(this::preDeleteHook)
-                .flatMap(getRepository()::delete);
-    }
-
-    /**
-     * A hook for subclasses that need a hook before *any* attempt to save the model instance.
-     *
-     * @param t The instance about to saved.
-     * @return The method must return its argument (possibly modified) as Mono, which will be saved
-     *         or an error (e.g. via {@link Mono#error(Throwable)}).
-     */
-    protected Mono<T> preSaveHook(T t) {
-        return Mono.just(t);
-    }
-
-
-    /**
-     * A hook for subclasses that need a hook before *any* attempt to save a newly created model instance.
-     *
-     * This will be run <i>before</i> the {@link #preSaveHook(Object)} and can contain create specific logic
-     * (if any).
-     *
-     * @param t The instance about to saved.
-     * @return The method must return its argument (possibly modified) as Mono, which will be saved
-     *         or an error (e.g. via {@link Mono#error(Throwable)}).
-     */
-    protected Mono<T> preCreateHook(T t) {
-        return Mono.just(t);
-    }
-
-    /**
-     * A hook for subclasses that need a hook before *any* attempt to save an updated model instance.
-     *
-     * This will be run <i>before</i> the {@link #preSaveHook(Object)} and can contain update specific logic
-     * (if any).
-     *
-     * @param current The copy of the instance in the database.
-     * @param update The instance provided externally with the changes.
-     * @return The method must return exactly one of the arguments (possibly modified) as Mono or an error
-     * (e.g. via {@link Mono#error(Throwable)}).  The return value is what will be saved (if it is not an
-     * error Mono).
-     */
-    protected Mono<T> preUpdateHook(T current, T update) {
-        return Mono.just(update);
-    }
-
-    /**
-     * A hook for subclasses that need a hook before *any* attempt to delete a model instance.
-     *
-     * The hook can prevent the removal by returning an error Mono (e.g. via {@link Mono#error(Throwable)}) or
-     * do service specific clean up related to the instance.
-     *
-     * @param t The instance about to be deleted
-     * @return The method must return the argument as a Mono or an error (e.g. via {@link Mono#error(Throwable)}).
-     */
-    protected Mono<T> preDeleteHook(T t) {
-        return Mono.just(t);
+    public Class<T> getModelClass() {
+        if (modelClass == null) {
+            this.modelClass = ReflectUtility.getConcreteModelClassForService(this.getClass());
+        }
+        return modelClass;
     }
 }

--- a/src/main/java/org/dcsa/core/service/impl/ExtendedBaseServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/ExtendedBaseServiceImpl.java
@@ -3,25 +3,9 @@ package org.dcsa.core.service.impl;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
 import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.core.service.ExtendedBaseService;
-import org.dcsa.core.util.ReflectUtility;
 import reactor.core.publisher.Flux;
 
-public abstract class ExtendedBaseServiceImpl<R extends ExtendedRepository<T, I>, T, I> extends BaseServiceImpl<R, T, I> implements ExtendedBaseService<T, I> {
-
-    private transient Class<T> modelClass;
-
-    @Override
-    public Class<T> getModelClass() {
-        if (modelClass == null) {
-            this.modelClass = ReflectUtility.getConcreteModelClassForService(this.getClass());
-        }
-        return modelClass;
-    }
-
-    @Override
-    public String getType() {
-        return getModelClass().getSimpleName();
-    }
+public abstract class ExtendedBaseServiceImpl<R extends ExtendedRepository<T, I>, T, I> extends BaseRepositoryBackedServiceImpl<R, T, I> implements ExtendedBaseService<T, I> {
 
     public I getIdOfEntity(T entity) {
         return getRepository().getIdOfEntity(entity);

--- a/src/main/java/org/dcsa/core/service/impl/ExtendedBaseServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/ExtendedBaseServiceImpl.java
@@ -13,7 +13,7 @@ public abstract class ExtendedBaseServiceImpl<R extends ExtendedRepository<T, I>
     @Override
     public Class<T> getModelClass() {
         if (modelClass == null) {
-            this.modelClass = ReflectUtility.getConcreteTypeVarOfSubclass(this.getClass(), 1, 3);
+            this.modelClass = ReflectUtility.getConcreteModelClassForService(this.getClass());
         }
         return modelClass;
     }

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -12,6 +12,17 @@ import java.util.function.Supplier;
 
 public class MappingUtils {
 
+    /* For use with ".buffer(...).concatMap(service::createOrUpdateOrDeleteAll), etc. where the underlying
+     * operation uses a variant "WHERE foo IN (LIST)".
+     *
+     * A higher number means fewer queries but after a certain size postgres performance will degrade.
+     * Plus a higher number will also require more memory (java-side) as we build up a list of items.
+     *
+     * The number should be sufficient to bundle most trivial things into a single query without hitting
+     * performance issues.
+     */
+    public static final int SQL_LIST_BUFFER_SIZE = 70;
+
     public static <C, S extends C, T extends C> T instanceFrom(S source, Supplier<T> targetConstructor, Class<C> clazz) {
         T target = targetConstructor.get();
         copyFields(source, target, clazz);

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -1,0 +1,61 @@
+package org.dcsa.core.util;
+
+import lombok.SneakyThrows;
+import org.springframework.data.annotation.Transient;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class MappingUtils {
+
+    public static <C, S extends C, T extends C> T instanceFrom(S source, Supplier<T> targetConstructor, Class<C> clazz) {
+        T target = targetConstructor.get();
+        copyFields(source, target, clazz);
+        return target;
+    }
+
+    @SneakyThrows({InvocationTargetException.class, IllegalAccessException.class})
+    public static <C, S extends C, T extends C> void copyFields(S source, T target, Class<C> clazz) {
+        /* Only clone the abstract fields that we know they share */
+        Class<?> currentClass = clazz;
+        Set<String> seenFields = new HashSet<>();
+        while (currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                String fieldName = field.getName();
+                Object value;
+                /* skip fields that have already been seen in a subclass */
+                if (!seenFields.add(fieldName)) {
+                    continue;
+                }
+                if (field.isAnnotationPresent(Transient.class)) {
+                    continue;
+                }
+                value = getFieldValue(source, field, currentClass);
+                try {
+                    field.set(target, value);
+                } catch (IllegalAccessException e) {
+                    ReflectUtility.setValueUsingMethod(target, currentClass, fieldName, field.getType(), value);
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+    }
+
+    private static Object getFieldValue(Object source, Field field, Class<?> declaringClass) throws InvocationTargetException, IllegalAccessException {
+        try {
+            return field.get(source);
+        } catch (IllegalAccessException e) {
+            Method getterMethod = getGetMethod(declaringClass, field.getName());
+            return getterMethod.invoke(source);
+        }
+    }
+
+    private static Method getGetMethod(Class<?> clazz, String fieldName) {
+        String capitalizedFieldName = ReflectUtility.capitalize(fieldName);
+        return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
+    }
+}


### PR DESCRIPTION
The DCSA-Core does very little for TO services and controllers, this PR attempts to make up for that.

We do this by making the basic service interface simpler to implement (notably moving `save()` out of that interface). With this, any TO service that can implement the (now) reduced basic service interface can now use the provided abstract Controller class.

Additionally, backport Mapping utilities and `SQL_LIST_BUFFER_SIZE` from EBL as they are also useful for e.g. TNT.