### PR TITLE
Improve our mapping support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<revision>0.8.6</revision>
+		<revision>0.8.7</revision>
 		<apache.commons.version>3.12.0</apache.commons.version>
 		<apache.commons.codec.version>1.15</apache.commons.codec.version>
 		<sha1/>

--- a/src/main/java/org/dcsa/core/model/ForeignKey.java
+++ b/src/main/java/org/dcsa/core/model/ForeignKey.java
@@ -1,5 +1,7 @@
 package org.dcsa.core.model;
 
+import org.springframework.data.relational.core.sql.Join;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,4 +16,6 @@ public @interface ForeignKey {
     String foreignFieldName();
 
     String viaJoinAlias() default "";
+
+    Join.JoinType joinType() default Join.JoinType.JOIN;
 }

--- a/src/main/java/org/dcsa/core/model/MapEntity.java
+++ b/src/main/java/org/dcsa/core/model/MapEntity.java
@@ -1,0 +1,12 @@
+package org.dcsa.core.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MapEntity {
+    String joinAlias() default "";
+}

--- a/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
+++ b/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
@@ -187,8 +187,9 @@ public class DefaultDBEntityAnalysisBuilder<T> implements DBEntityAnalysis.DBEnt
                 String rhsColumnName = getColumnName(intoModelType, foreignKey.foreignFieldName(), "rhs");
                 Table rhsTable = getTableForModel(intoModelType, intoJoinAlias);
                 Column rhsColumn = Column.create(SqlIdentifier.unquoted(rhsColumnName), rhsTable);
+                Join.JoinType joinType = foreignKey.joinType();
 
-                SimpleJoinDescriptor joinDescriptor = SimpleJoinDescriptor.of(Join.JoinType.JOIN, lhsColumn, rhsColumn, intoModelType, joinAlias);
+                SimpleJoinDescriptor joinDescriptor = SimpleJoinDescriptor.of(joinType, lhsColumn, rhsColumn, intoModelType, joinAlias);
                 registerJoinDescriptor(joinDescriptor);
 
                 // load fields recursively with new prefix

--- a/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
+++ b/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.sql.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -119,7 +120,7 @@ public class DefaultDBEntityAnalysisBuilder<T> implements DBEntityAnalysis.DBEnt
     private void loadFieldFromModelClass() {
         ReflectUtility.visitAllFields(
                 entityType,
-                field -> !field.isAnnotationPresent(Transient.class),
+                field -> !field.isAnnotationPresent(Transient.class) && !Modifier.isStatic(field.getModifiers()),
                 field -> this.registerField(field, null, true)
         );
     }
@@ -143,6 +144,9 @@ public class DefaultDBEntityAnalysisBuilder<T> implements DBEntityAnalysis.DBEnt
         }
 
         for (Field field : modelType.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
             if (field.isAnnotationPresent(ForeignKey.class)) {
                 ForeignKey foreignKey = field.getAnnotation(ForeignKey.class);
                 String intoFieldName = foreignKey.into();


### PR DESCRIPTION
This PR provides the following bug fixes and improvements to the mapping support:

- We no longer attempt to map static fields.  That was never intended and an oversight in the original code.
- We now support LEFT JOIN for `@ForeignKey` mappings
- We add support for mapping an entity via a Join from `@JoinedWithModel` without having to use `@ForeignKey`. This is useful for more complex join operations that cannot be described by `@ForeignKey`.

