### PR TITLE
Remove padding in encoded cursor values

### DIFF
--- a/src/main/java/org/dcsa/core/extendedrequest/ExtendedRequest.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/ExtendedRequest.java
@@ -451,7 +451,7 @@ public class ExtendedRequest<T> {
         if (encryptionKey != null) {
             parameters = encrypt(encryptionKey, parameters);
         }
-        return getExtendedParameters().getPaginationCursorName() + CURSOR_SPLIT + Base64.getUrlEncoder().encodeToString(parameters);
+        return getExtendedParameters().getPaginationCursorName() + CURSOR_SPLIT + Base64.getUrlEncoder().withoutPadding().encodeToString(parameters);
     }
 
     @RequiredArgsConstructor(staticName = "of")


### PR DESCRIPTION
The "=" padding character can cause issues in some URL decoding
situations.  Since we do not need it, we might as well remove the
padding.

Signed-off-by: Niels Thykier <nt@asseco.dk>