### PR TITLE
DDT-319: Revise security code to better support AWS cognito

### DIFF
--- a/src/main/java/org/dcsa/core/security/AudienceValidator.java
+++ b/src/main/java/org/dcsa/core/security/AudienceValidator.java
@@ -20,6 +20,12 @@ public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
     }
 
     public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        if (jwt.getAudience() == null) {
+            if (this.audience.equals("NONE")) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(error);
+        }
         if (jwt.getAudience().contains(audience)) {
             return OAuth2TokenValidatorResult.success();
         }

--- a/src/main/java/org/dcsa/core/security/ClaimsOneOfValueValidator.java
+++ b/src/main/java/org/dcsa/core/security/ClaimsOneOfValueValidator.java
@@ -1,0 +1,44 @@
+package org.dcsa.core.security;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Set;
+
+/**
+ * Validates that the JWT token contains the intended audience in its claims.
+ */
+@RequiredArgsConstructor(staticName = "of")
+public class ClaimsOneOfValueValidator implements OAuth2TokenValidator<Jwt> {
+
+    private final String claimName;
+    private final Set<String> oneOf;
+
+    private OAuth2TokenValidatorResult missingClaim() {
+        return OAuth2TokenValidatorResult.failure(new OAuth2Error("invalid_token", "The required claim " + claimName + " is missing", null));
+    }
+
+    private OAuth2TokenValidatorResult notMatchingExpectedClaimValue() {
+        return OAuth2TokenValidatorResult.failure(new OAuth2Error("invalid_token", "The required claim " + claimName + " did not match one of the valid values", null));
+    }
+
+
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        if (claimName.equals("") || oneOf.isEmpty()) {
+            // No requirements, then we accept
+            return OAuth2TokenValidatorResult.success();
+        }
+        String claimValue = jwt.getClaimAsString(claimName);
+        if (claimValue == null) {
+            return missingClaim();
+        }
+        if (oneOf.contains(claimValue)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+        return notMatchingExpectedClaimValue();
+    }
+}

--- a/src/main/java/org/dcsa/core/security/SecurityConfig.java
+++ b/src/main/java/org/dcsa/core/security/SecurityConfig.java
@@ -16,6 +16,12 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
 /**
  * Configures our application with Spring Security to restrict access to our API endpoints.
  */
@@ -26,11 +32,20 @@ public class SecurityConfig {
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuer;
 
-    @Value("${auth0.audience}")
+    @Value("${dcsa.securityConfig.jwt.audience}")
     private String audience;
 
-    @Value("${auth0.enabled}")
+    @Value("${dcsa.securityConfig.jwt.claim.name:}")
+    private String claimName;
+
+    @Value("${dcsa.securityConfig.jwt.claim.value:}")
+    private String claimValue;
+
+    @Value("${dcsa.securityConfig.auth.enabled}")
     private boolean securityEnabled;
+
+    @Value("${dcsa.securityConfig.csrf.enabled:false}")
+    private boolean csrfEnabled;
 
     @Value("${dcsa.securityConfig.receiveNotificationEndpoint:NONE}")
     private String receiveNotificationEndpoint;
@@ -58,6 +73,7 @@ public class SecurityConfig {
 
         if (securityEnabled) {
             String endpoint = null;
+            log.info("Security: auth enabled (dcsa.securityConfig.auth.enabled)");
             if (!receiveNotificationEndpoint.equals("NONE")) {
                 endpoint = receiveNotificationEndpoint.replaceAll("/++$", "") + "/receive/*";
                 securitySpec = securitySpec.pathMatchers(HttpMethod.POST, endpoint)
@@ -65,9 +81,17 @@ public class SecurityConfig {
                         .pathMatchers(HttpMethod.HEAD, endpoint)
                         .permitAll();
 
-                log.info("Security: auth0 enabled - receive endpoint \"" + endpoint + "\"");
+                log.info("Security: receive endpoint \"" + endpoint + "\"");
             } else {
-                log.info("Security: auth0 enabled - no receive endpoint");
+                log.info("Security: No receive receive endpoint");
+            }
+            log.info("Security: JWT audience required: " + audience);
+            if (!claimName.equals("") && !claimValue.equals("")) {
+                String values = String.join(", ", claimValue);
+                log.info("Security: JWT claims must have claim \"" + claimName + "\" containing one of: " + values);
+                log.info("Security: JWT claims can be controlled via dcsa.securityConfig.jwt.claim.{name,value}");
+            } else {
+                log.info("Security: No claim requirements for JWT tokens (dcsa.securityConfig.jwt.claim.{name,value})");
             }
             ServerHttpSecurity security = securitySpec.anyExchange().authenticated()
                     .and()
@@ -83,9 +107,14 @@ public class SecurityConfig {
                         ServerWebExchangeMatchers.pathMatchers(endpoint)
                 ));
             }
-
+            if (csrfEnabled) {
+                log.info("Security: CSRF tokens required (dcsa.securityConfig.csrf.enabled)");
+            } else {
+                security.csrf().disable();
+                log.info("Security: CSRF tokens disabled (dcsa.securityConfig.csrf.enabled)");
+            }
         } else {
-            log.info("Security: disabled - no authentication nor CRSF tokens needed");
+            log.info("Security: disabled - no authentication nor CSRF tokens needed (dcsa.securityConfig.{auth,csrf}.enabled)");
             securitySpec.anyExchange().permitAll()
             .and()
                     .csrf().disable();
@@ -106,9 +135,10 @@ public class SecurityConfig {
                 ReactiveJwtDecoders.fromOidcIssuerLocation(issuer);
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(audience);
+        OAuth2TokenValidator<Jwt> jwtValidator = ClaimsOneOfValueValidator.of(claimName, Set.of(claimValue));
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuer);
         OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator,
-                new JwtTimestampValidator());
+                jwtValidator, new JwtTimestampValidator());
 
         jwtDecoder.setJwtValidator(withAudience);
         return jwtDecoder;

--- a/src/main/java/org/dcsa/core/security/SecurityConfig.java
+++ b/src/main/java/org/dcsa/core/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuer;
 
-    @Value("${dcsa.securityConfig.jwt.audience}")
+    @Value("${dcsa.securityConfig.jwt.audience:localhost}")
     private String audience;
 
     @Value("${dcsa.securityConfig.jwt.claim.name:}")
@@ -41,7 +41,7 @@ public class SecurityConfig {
     @Value("${dcsa.securityConfig.jwt.claim.value:}")
     private String claimValue;
 
-    @Value("${dcsa.securityConfig.auth.enabled}")
+    @Value("${dcsa.securityConfig.auth.enabled:false}")
     private boolean securityEnabled;
 
     @Value("${dcsa.securityConfig.csrf.enabled:false}")


### PR DESCRIPTION
Spring boot already provides the basic features for this.  This commit
is mostly about expanding our own validation on top of that to ensure
we can support the cluster requirements.

The CSRF token is made conditional (optional) because most API users
will not provide a CSRF token (as it is not a part of our standard).

Signed-off-by: Niels Thykier <nt@asseco.dk>