### PR TITLE
GlobalExceptionHandler: warn on unhandled exceptions

### DIFF
--- a/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
@@ -5,10 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.dcsa.core.exception.*;
 import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.r2dbc.BadSqlGrammarException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebInputException;
 
 import javax.validation.ConstraintViolationException;
@@ -88,10 +90,14 @@ public class GlobalExceptionHandler {
     throw new InputParsingException(ce.getLocalizedMessage(), ce);
   }
 
-  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(Exception.class)
-  public void handleAllExceptions(Exception ex) {
+  public ResponseEntity<?> handleAllExceptions(Exception ex) {
     log.warn("Unhandled exception", ex);
+    if (ex instanceof ResponseStatusException) {
+      return ResponseEntity.status(((ResponseStatusException) ex).getStatus()).build();
+    } else {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 
   private void logExceptionTraceIfEnabled(Exception ex) {

--- a/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
@@ -92,10 +92,10 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<?> handleAllExceptions(Exception ex) {
-    log.warn("Unhandled exception", ex);
     if (ex instanceof ResponseStatusException) {
       return ResponseEntity.status(((ResponseStatusException) ex).getStatus()).build();
     } else {
+      log.warn("Unhandled exception", ex);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }

--- a/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
@@ -91,11 +91,7 @@ public class GlobalExceptionHandler {
   @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(Exception.class)
   public void handleAllExceptions(Exception ex) {
-    log.debug(
-        "{} error! caused by : {}",
-        this.getClass().getSimpleName(),
-        null != ex.getLocalizedMessage() ? ex.getLocalizedMessage() : ex.getMessage());
-    logExceptionTraceIfEnabled(ex);
+    log.warn("Unhandled exception", ex);
   }
 
   private void logExceptionTraceIfEnabled(Exception ex) {


### PR DESCRIPTION
We would like to know if we have unhandled exceptions and these should
provide a stacktrace so we can debug those.

Signed-off-by: Niels Thykier <nt@asseco.dk>