### PR TITLE
DDT-110 Error format

### DIFF
--- a/.github/workflows/runTNTTests.yml
+++ b/.github/workflows/runTNTTests.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dcsaorg/DCSA-API-Validator
-          ref: master
+          ref: DDT-110-new-error-format
           token: ${{ secrets.REPO_ACCESS_PAT }}
           path: DCSA-API-Validator
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<revision>0.8.24</revision>
+		<revision>0.8.25</revision>
 		<apache.commons.version>3.12.0</apache.commons.version>
 		<apache.commons.codec.version>1.15</apache.commons.codec.version>
 		<sha1/>

--- a/src/main/java/org/dcsa/core/controller/BaseController.java
+++ b/src/main/java/org/dcsa/core/controller/BaseController.java
@@ -1,11 +1,9 @@
 package org.dcsa.core.controller;
 
 import lombok.extern.slf4j.Slf4j;
-import org.dcsa.core.exception.CreateException;
-import org.dcsa.core.exception.DeleteException;
-import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.BaseService;
 import org.springframework.http.HttpStatus;
+import org.dcsa.core.exception.*;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -63,14 +61,14 @@ public abstract class BaseController<S extends BaseService<T, I>, T, I> {
     // Error handling
 
     public Mono<Void> deleteMonoError() {
-        return Mono.error(new DeleteException("No Id provided in " + getType() + " object"));
+        return Mono.error(ConcreteRequestErrorMessageException.invalidParameter(getType(), null, "No Id provided in " + getType() + " object"));
     }
 
     public Mono<T> updateMonoError() {
-        return Mono.error(new UpdateException("Id in url does not match id in body"));
+        return Mono.error(ConcreteRequestErrorMessageException.invalidParameter("Id in url does not match id in body"));
     }
 
     public Mono<T> createMonoError() {
-        return Mono.error(new CreateException("Id not allowed when creating a new " + getType()));
+        return Mono.error(ConcreteRequestErrorMessageException.invalidParameter(getType(), null, "Id not allowed when creating a new " + getType()));
     }
 }

--- a/src/main/java/org/dcsa/core/exception/BadRequestException.java
+++ b/src/main/java/org/dcsa/core/exception/BadRequestException.java
@@ -1,0 +1,12 @@
+package org.dcsa.core.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+class BadRequestException extends ConcreteRequestErrorMessageException {
+
+    BadRequestException(String reason, Object reference, String message, Throwable cause) {
+        super(reason, reference, message, cause);
+    }
+}

--- a/src/main/java/org/dcsa/core/exception/ConcreteRequestErrorMessageException.java
+++ b/src/main/java/org/dcsa/core/exception/ConcreteRequestErrorMessageException.java
@@ -1,0 +1,92 @@
+package org.dcsa.core.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.Getter;
+import org.dcsa.core.model.transferobjects.ConcreteRequestErrorMessageTO;
+
+public abstract class ConcreteRequestErrorMessageException extends DCSAException {
+
+    @Getter
+    private final String reason;
+
+    @Getter
+    private final Object reference;
+
+
+    protected ConcreteRequestErrorMessageException(String reason, Object reference, String message) {
+        super(message);
+        this.reference = reference;
+        this.reason = reason;
+    }
+
+    protected ConcreteRequestErrorMessageException(String reason, Object reference, String message, Throwable cause) {
+        super(message, cause);
+        this.reference = reference;
+        this.reason = reason;
+    }
+
+    public ConcreteRequestErrorMessageTO asConcreteRequestMessage() {
+        return new ConcreteRequestErrorMessageTO(getReason(), getMessage());
+    }
+
+    public static ConcreteRequestErrorMessageException notFound(String message) {
+        return notFound(message, null);
+    }
+
+    public static ConcreteRequestErrorMessageException notFound(String message, Throwable cause) {
+        return new NotFoundException("notFound", null, message, cause);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidInput(String message, Throwable cause) {
+        return new BadRequestException("invalidInput", null, message, cause);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidQuery(String queryParameter, String message) {
+        return invalidQuery(queryParameter, message, null);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidQuery(String queryParameter, String message, Throwable cause) {
+        return new BadRequestException("invalidQuery", queryParameter, message, cause);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidParameter(String message) {
+        return invalidParameter(null, null, message, null);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidParameter(String message, Throwable cause) {
+        return new BadRequestException("invalidParameter", null, message, cause);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidParameter(String entityName, String attributePath, String message) {
+        return invalidParameter(entityName, attributePath, message, null);
+    }
+
+    public static ConcreteRequestErrorMessageException invalidParameter(String entityName, String attributePath, String message, Throwable cause) {
+        return new BadRequestException("invalidParameter", AttributeReference.of(entityName, attributePath), message, cause);
+    }
+
+    public static ConcreteRequestErrorMessageException internalServerError(String message) {
+        return internalServerError(message, null);
+    }
+
+    public static ConcreteRequestErrorMessageException internalServerError(String message, Throwable cause) {
+        return new InternalServerErrorException("internalError", null, message, cause);
+    }
+
+    @Data
+    private static class AttributeReference {
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private final String attributeName;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private final String entityName;
+
+        static AttributeReference of(String attributeName, String entityName) {
+            if (attributeName == null && entityName == null) {
+                return null;
+            }
+            return new AttributeReference(attributeName, entityName);
+        }
+    }
+}

--- a/src/main/java/org/dcsa/core/exception/CreateException.java
+++ b/src/main/java/org/dcsa/core/exception/CreateException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated see {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class CreateException extends DCSAException {
   public CreateException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/DatabaseException.java
+++ b/src/main/java/org/dcsa/core/exception/DatabaseException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated use {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
 public class DatabaseException extends DCSAException {
   public DatabaseException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/DeleteException.java
+++ b/src/main/java/org/dcsa/core/exception/DeleteException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated see {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class DeleteException extends DCSAException {
   public DeleteException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/GetException.java
+++ b/src/main/java/org/dcsa/core/exception/GetException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated use {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class GetException extends DCSAException {
   public GetException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/InputParsingException.java
+++ b/src/main/java/org/dcsa/core/exception/InputParsingException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated use {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class InputParsingException extends DCSAException {
   public InputParsingException(String message, Throwable cause) {

--- a/src/main/java/org/dcsa/core/exception/InternalServerErrorException.java
+++ b/src/main/java/org/dcsa/core/exception/InternalServerErrorException.java
@@ -1,0 +1,12 @@
+package org.dcsa.core.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+class InternalServerErrorException extends ConcreteRequestErrorMessageException {
+
+    InternalServerErrorException(String reason, Object reference, String message, Throwable cause) {
+        super(reason, reference, message, cause);
+    }
+}

--- a/src/main/java/org/dcsa/core/exception/InvalidParameterException.java
+++ b/src/main/java/org/dcsa/core/exception/InvalidParameterException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated use {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException#invalidParameter(String)}.
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class InvalidParameterException extends DCSAException {
   public InvalidParameterException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/NotFoundException.java
+++ b/src/main/java/org/dcsa/core/exception/NotFoundException.java
@@ -4,8 +4,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(value = HttpStatus.NOT_FOUND)
-public class NotFoundException extends DCSAException {
+public class NotFoundException extends ConcreteRequestErrorMessageException {
+
+  /**
+   * @deprecated use {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException#notFound(String)}.
+   */
+  @Deprecated
   public NotFoundException(String errorMessage) {
-    super(errorMessage);
+    super(null, null, errorMessage, null);
+  }
+
+  NotFoundException(String reason, Object reference, String message, Throwable cause) {
+    super(reason, reference, message, cause);
   }
 }

--- a/src/main/java/org/dcsa/core/exception/UpdateException.java
+++ b/src/main/java/org/dcsa/core/exception/UpdateException.java
@@ -3,6 +3,10 @@ package org.dcsa.core.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Deprecated
+/**
+ * @deprecated see {@link org.dcsa.core.exception.ConcreteRequestErrorMessageException}.
+ */
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class UpdateException extends DCSAException {
   public UpdateException(String errorMessage) {

--- a/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler {
     }
 
     ConcreteRequestErrorMessageTO errorEntity =
-        new ConcreteRequestErrorMessageTO("internal_error", dcsaEx.getMessage());
+        new ConcreteRequestErrorMessageTO(httpStatus.getReasonPhrase(), dcsaEx.getMessage());
 
     RequestFailureTO failureTO =
         new RequestFailureTO(
@@ -73,7 +73,7 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(failureTO, httpStatus);
   }
 
-  @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "invalid_input.")
+  @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "invalidInput")
   @ExceptionHandler(ConstraintViolationException.class)
   public void badRequest(ConstraintViolationException cvex) {
     log.debug("Input error : {}", cvex.getConstraintViolations());

--- a/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/dcsa/core/exception/handler/GlobalExceptionHandler.java
@@ -23,6 +23,23 @@ import java.util.List;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  @ExceptionHandler(ConcreteRequestErrorMessageException.class)
+  public ResponseEntity<RequestFailureTO> handle(ServerHttpRequest serverHttpRequest, ConcreteRequestErrorMessageException ex) {
+    ResponseStatus responseStatusAnnotation = ex.getClass().getAnnotation(ResponseStatus.class);
+    HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+    ConcreteRequestErrorMessageTO errorEntity = ex.asConcreteRequestMessage();
+    if (responseStatusAnnotation != null) {
+      httpStatus = responseStatusAnnotation.value();
+    }
+    RequestFailureTO failureTO = new RequestFailureTO(
+            serverHttpRequest.getMethodValue(),
+            serverHttpRequest.getURI().toString(),
+            List.of(errorEntity),
+            httpStatus
+    );
+    return new ResponseEntity<>(failureTO, httpStatus);
+  }
+
   @ExceptionHandler(DCSAException.class)
   public void handleDCSAExceptions(DCSAException dcsaEx) {
     log.debug(
@@ -75,23 +92,6 @@ public class GlobalExceptionHandler {
     } else {
       throw ex;
     }
-  }
-
-  @ExceptionHandler(ConcreteRequestErrorMessageException.class)
-  public ResponseEntity<RequestFailureTO> handle(ServerHttpRequest serverHttpRequest, ConcreteRequestErrorMessageException ex) {
-    ResponseStatus responseStatusAnnotation = ex.getClass().getAnnotation(ResponseStatus.class);
-    HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-    ConcreteRequestErrorMessageTO errorEntity = ex.asConcreteRequestMessage();
-    if (responseStatusAnnotation != null) {
-      httpStatus = responseStatusAnnotation.value();
-    }
-    RequestFailureTO failureTO = new RequestFailureTO(
-            serverHttpRequest.getMethodValue(),
-            serverHttpRequest.getURI().toString(),
-            List.of(errorEntity),
-            httpStatus
-    );
-    return new ResponseEntity<>(failureTO, httpStatus);
   }
 
   // Spring's default handler for unknown JSON properties is useless for telling the user

--- a/src/main/java/org/dcsa/core/model/transferobjects/ConcreteRequestErrorMessageTO.java
+++ b/src/main/java/org/dcsa/core/model/transferobjects/ConcreteRequestErrorMessageTO.java
@@ -1,0 +1,10 @@
+package org.dcsa.core.model.transferobjects;
+
+import lombok.Data;
+
+@Data
+public class ConcreteRequestErrorMessageTO {
+
+    private final String reason;
+    private final String message;
+}

--- a/src/main/java/org/dcsa/core/model/transferobjects/RequestFailureTO.java
+++ b/src/main/java/org/dcsa/core/model/transferobjects/RequestFailureTO.java
@@ -1,0 +1,31 @@
+package org.dcsa.core.model.transferobjects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Data
+public class RequestFailureTO {
+
+    private final String httpMethod;
+
+    private final String requestUri;
+
+    private final List<ConcreteRequestErrorMessageTO> errors;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+
+    public String getStatusCodeText() {
+        return httpStatus.getReasonPhrase();
+    }
+
+    private final ZonedDateTime errorDateTime = ZonedDateTime.now();
+}

--- a/src/main/java/org/dcsa/core/service/impl/BaseRepositoryBackedServiceImpl.java
+++ b/src/main/java/org/dcsa/core/service/impl/BaseRepositoryBackedServiceImpl.java
@@ -1,5 +1,6 @@
 package org.dcsa.core.service.impl;
 
+import org.dcsa.core.exception.ConcreteRequestErrorMessageException;
 import org.dcsa.core.exception.NotFoundException;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +20,7 @@ public abstract class BaseRepositoryBackedServiceImpl<R extends R2dbcRepository<
     @Override
     public Mono<T> findById(final I id) {
         return getRepository().findById(id)
-                .switchIfEmpty(Mono.error(new NotFoundException("No " + getType() + " was found with id: " + id)));
+                .switchIfEmpty(Mono.error(ConcreteRequestErrorMessageException.notFound("No " + getType() + " was found with id: " + id)));
     }
 
     @Transactional


### PR DESCRIPTION
Add ConcreteRequestErrorMessageException to align error format to specification. 

Old DCSAExceptions are marked `@Deprecated`. Most of them are migrated to ConcreteRequestErrorMessageException. 

As stated in #72 , we still need to convert exceptions in the other repositories and add missing reasons for those.

Closes: #72 