### PR TITLE
DateRange validation via `@DateRange`

### DIFF
--- a/src/main/java/org/dcsa/core/util/ReflectUtility.java
+++ b/src/main/java/org/dcsa/core/util/ReflectUtility.java
@@ -82,12 +82,26 @@ public class ReflectUtility {
      * @return the method corresponding to fieldName with valueFieldTypes as arguments
      */
     public static Method getSetterMethodFromName(Class<?> clazz, String fieldName, Class<?>... valueFieldTypes) {
+        return getAccessorFromName(clazz, "set", fieldName, valueFieldTypes);
+    }
+
+    /**
+     * Finds the getter method on clazz corresponding to the name fieldName with the arguments valueFieldTypes
+     * @param clazz the class to investigate
+     * @param fieldName the name of the field to find a getter method for
+     * @return the method corresponding to fieldName with valueFieldTypes as arguments
+     */
+    public static Method getGetterMethodFromName(Class<?> clazz, String fieldName) {
+        return getAccessorFromName(clazz, "get", fieldName);
+    }
+
+    private static Method getAccessorFromName(Class<?> clazz, String prefix, String fieldName, Class<?> ... valueFieldTypes) {
         try {
             // Try the raw field name as a method call
             return getMethod(clazz, fieldName, valueFieldTypes);
         } catch (Exception exception) {
             String capitalizedFieldName = capitalize(fieldName);
-            return getMethod(clazz, "set" + capitalizedFieldName, valueFieldTypes);
+            return getMethod(clazz, prefix + capitalizedFieldName, valueFieldTypes);
         }
     }
 
@@ -95,7 +109,7 @@ public class ReflectUtility {
      * Investigate if a class contains a method be the name methodName with arguments corresponding to valueFieldTypes.
      * The method must be public.
      * Throws a MethodNotFoundException if the method requested is not public or does not exist
-     * @param clazz the class to invistigate
+     * @param clazz the class to investigate
      * @param methodName name of the method to return
      * @param valueFieldTypes arguments for the method to return
      * @return the public method corresponding to methodName and with the arguments containing valueFieldTypes

--- a/src/main/java/org/dcsa/core/validator/DateRange.java
+++ b/src/main/java/org/dcsa/core/validator/DateRange.java
@@ -1,0 +1,61 @@
+package org.dcsa.core.validator;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DateRangeValidator.class)
+public @interface DateRange {
+
+    /**
+     * Name of the field that defines the start of the range
+     */
+    String startField();
+
+    /**
+     * Name of the field that defines the end of the range
+     */
+    String endField();
+
+    /**
+     * Whether at least one of the fields must be provided.
+     *
+     * This is only useful if both are nullable, but you want to ensure that at
+     * least one of them is present.
+     *
+     * If you want to require one or both of the fields to be not null, then please
+     * use @{@link javax.validation.constraints.NotNull} on the relevant fields in
+     * addition to this annotation.
+     */
+    NullHandling nullHandling() default NullHandling.BOTH_CAN_BE_NULL;
+
+    /**
+     * Whether the startField and endField can have the same value <i>>when not null</i>
+     *
+     * This does not affect null handling. Use {@link #nullHandling()} for deciding whether
+     * both fields may be null.
+     */
+    EqualHandling equalHandling() default EqualHandling.EQUAL_OK;
+
+    enum EqualHandling {
+        EQUAL_OK,
+        EQUAL_INVALID,
+    }
+
+    /**
+     * How to handle when one of both of the fields are null
+     *
+     * For "neither may be null", please use @NonNull instead.
+     */
+    enum NullHandling {
+        AT_LEAST_ONE_MUST_BE_NONNULL,
+        BOTH_CAN_BE_NULL,
+    }
+}

--- a/src/main/java/org/dcsa/core/validator/DateRange.java
+++ b/src/main/java/org/dcsa/core/validator/DateRange.java
@@ -8,6 +8,15 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * Validates that two fields on the entity is a valid date range
+ *
+ * Concretely, this can be used to validate that:
+ * <ul>
+ *     <li>the start date is before or (optionally) equal to the end date</li>
+ *     <li>(optionally) at least start date <i>OR</i> end date is given. Combine with @{@link javax.validation.constraints.NotNull} as needed</li>
+ * </ul>
+ */
 @Target({TYPE})
 @Retention(RUNTIME)
 @Documented

--- a/src/main/java/org/dcsa/core/validator/DateRangeValidator.java
+++ b/src/main/java/org/dcsa/core/validator/DateRangeValidator.java
@@ -10,13 +10,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.temporal.Temporal;
 
-/**
- * Validator for Enumeration subsets. Works both for queryParameters (where the value to validate is
- * a string) and for Enum defined fields (where the value to validate is an Enum)
- *
- * <p>If the value is a string - then this class supports that the string can be comma separated in
- * order to validate a set of values
- */
 public class DateRangeValidator implements ConstraintValidator<DateRange, Object> {
 
   private String startFieldName;

--- a/src/main/java/org/dcsa/core/validator/DateRangeValidator.java
+++ b/src/main/java/org/dcsa/core/validator/DateRangeValidator.java
@@ -1,0 +1,103 @@
+package org.dcsa.core.validator;
+
+import org.dcsa.core.util.ReflectUtility;
+
+import javax.el.MethodNotFoundException;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.temporal.Temporal;
+
+/**
+ * Validator for Enumeration subsets. Works both for queryParameters (where the value to validate is
+ * a string) and for Enum defined fields (where the value to validate is an Enum)
+ *
+ * <p>If the value is a string - then this class supports that the string can be comma separated in
+ * order to validate a set of values
+ */
+public class DateRangeValidator implements ConstraintValidator<DateRange, Object> {
+
+  private String startFieldName;
+  private String endFieldName;
+  private DateRange.NullHandling nullHandling;
+  private DateRange.EqualHandling equalHandling;
+
+  @Override
+  public void initialize(DateRange constraintAnnotation) {
+    this.startFieldName = constraintAnnotation.startField();
+    this.endFieldName = constraintAnnotation.endField();
+    this.nullHandling = constraintAnnotation.nullHandling();
+    this.equalHandling = constraintAnnotation.equalHandling();
+  }
+
+  @Override
+  public boolean isValid(Object entity, ConstraintValidatorContext constraintValidatorContext) {
+    if (null == entity) {
+      return true;
+    }
+    return this.isValidImpl(entity, constraintValidatorContext);
+  }
+
+  private <T extends Comparable<T>> boolean isValidImpl(Object entity, ConstraintValidatorContext constraintValidatorContext) {
+    Field startField, endField;
+    Method startFieldGetter, endFieldGetter;
+    T startDateValue, endDateValue;
+    Class<?> dateType;
+    try {
+      startField = ReflectUtility.getDeclaredField(entity.getClass(), startFieldName);
+      endField = ReflectUtility.getDeclaredField(entity.getClass(), endFieldName);
+
+      startFieldGetter = ReflectUtility.getGetterMethodFromName(entity.getClass(), startFieldName);
+      endFieldGetter = ReflectUtility.getGetterMethodFromName(entity.getClass(), endFieldName);
+    } catch (NoSuchFieldException|MethodNotFoundException e) {
+      throw new IllegalStateException("Invalid @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The entity does not have both of the fields " + startFieldName + " and " + endFieldName, e);
+    }
+    dateType = startField.getType();
+    if (!Temporal.class.isAssignableFrom(dateType) || !Comparable.class.isAssignableFrom(dateType)) {
+      throw new IllegalStateException("Invalid @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The type of " + startFieldName + " must be a Comparable & Temporal (such as ZonedDateTime)");
+    }
+    if (!dateType.equals(startFieldGetter.getReturnType())) {
+      throw new IllegalStateException("Invalid @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The field and getter methods disagree on the return type for " + startFieldName);
+    }
+    if (!dateType.equals(endField.getType())) {
+      throw new IllegalStateException("Invalid @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The fields " + startFieldName + " and " + endFieldName + " must have the same type");
+    }
+    if (!startFieldGetter.getReturnType().equals(endFieldGetter.getReturnType())) {
+      throw new IllegalStateException("Invalid @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The getters for " + startFieldName + " and " + endFieldName + " must have the same return type");
+    }
+    try {
+      startDateValue = cast(startFieldGetter.invoke(entity));
+      endDateValue = cast(endFieldGetter.invoke(entity));
+    } catch (IllegalAccessException|InvocationTargetException e) {
+      throw new IllegalStateException("Issue with @DateRange annotation for entity " + entity.getClass().getSimpleName()
+              + ": The getter for " + startFieldName + " or " + endFieldName + " triggered an exception!");
+    }
+
+    if (startDateValue == null || endDateValue == null) {
+      if (startDateValue == null && endDateValue == null) {
+        return this.nullHandling == DateRange.NullHandling.BOTH_CAN_BE_NULL;
+      }
+      return true;
+    }
+
+    int comparison = startDateValue.compareTo(endDateValue);
+    if (comparison == 0) {
+      return this.equalHandling == DateRange.EqualHandling.EQUAL_OK;
+    }
+    return comparison < 0;
+  }
+
+  // Helper to deal compiler warnings about unchecked casts.
+  private static <T> T cast(Object value) {
+    @SuppressWarnings("unchecked")
+    T t = (T)value;
+    return t;
+  }
+}

--- a/src/test/java/org/dcsa/core/validator/DateRangeValidatorTest.java
+++ b/src/test/java/org/dcsa/core/validator/DateRangeValidatorTest.java
@@ -1,0 +1,176 @@
+package org.dcsa.core.validator;
+
+import lombok.Data;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+@ExtendWith(MockitoExtension.class)
+public class DateRangeValidatorTest {
+
+    private final LocalDate DATE_19900101 = LocalDate.of(1990, 1, 1);
+    private final LocalDate DATE_20200101 = LocalDate.of(2020, 1, 1);
+
+    @Mock
+    private ConstraintValidatorContext constraintValidatorContext;
+
+    @Test
+    public void testValidatorDefaults() {
+        // Valid cases
+        Assertions.assertTrue(validate(DateRangeDefaults.of(DATE_19900101, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeDefaults.of(DATE_19900101, DATE_19900101)));
+        Assertions.assertTrue(validate(DateRangeDefaults.of(null, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeDefaults.of(DATE_19900101, null)));
+        Assertions.assertTrue(validate(DateRangeDefaults.of(null, null)));
+
+        // Invalid
+        Assertions.assertFalse(validate(DateRangeDefaults.of(DATE_20200101, DATE_19900101)));
+    }
+
+    @Test
+    public void testValidatorAtLeastOne() {
+        // Valid cases
+        Assertions.assertTrue(validate(DateRangeAtLeastOne.of(DATE_19900101, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeAtLeastOne.of(DATE_19900101, DATE_19900101)));
+        Assertions.assertTrue(validate(DateRangeAtLeastOne.of(null, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeAtLeastOne.of(DATE_19900101, null)));
+
+        // Invalid
+        Assertions.assertFalse(validate(DateRangeAtLeastOne.of(DATE_20200101, DATE_19900101)));
+        Assertions.assertFalse(validate(DateRangeAtLeastOne.of(null, null)));
+    }
+
+
+    @Test
+    public void testValidatorNotEqual() {
+        // Valid cases
+        Assertions.assertTrue(validate(DateRangeNotEqual.of(DATE_19900101, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeNotEqual.of(null, DATE_20200101)));
+        Assertions.assertTrue(validate(DateRangeNotEqual.of(DATE_19900101, null)));
+        Assertions.assertTrue(validate(DateRangeNotEqual.of(null, null)));
+
+        // Invalid
+        Assertions.assertFalse(validate(DateRangeNotEqual.of(DATE_20200101, DATE_19900101)));
+        Assertions.assertFalse(validate(DateRangeNotEqual.of(DATE_19900101, DATE_19900101)));
+    }
+
+    @Test
+    public void testInvalidAnnotation() {
+        assertInvalidAnnotation(MissingEndDate.of(DATE_19900101));
+        assertInvalidAnnotation(ConflictingFieldTypes.of(DATE_19900101, null));
+        assertInvalidAnnotation(ConflictingMethodTypes.of(DATE_19900101, DATE_20200101));
+        assertInvalidAnnotation(ConflictingFieldVsMethodTypes.of(DATE_19900101, DATE_20200101));
+        // NotDeclaredAsTemporal should fail even though the values are dates because we want to
+        // emulate a compiler level type check with the exception.
+        assertInvalidAnnotation(NotDeclaredAsTemporal.of(DATE_19900101, DATE_20200101));
+        assertInvalidAnnotation(GetterThrowsException.of(DATE_19900101, DATE_20200101));
+    }
+
+    @Test
+    public void testNull() {
+        // Not entirely sure this case makes sense, but it is a conditional in the validator
+        Assertions.assertTrue(validate(null));
+    }
+
+    private boolean validate(Object value) {
+        DateRangeValidator rangeValidator = new DateRangeValidator();
+        if (value != null) {
+            DateRange rangeAnno = value.getClass().getAnnotation(DateRange.class);
+            rangeValidator.initialize(rangeAnno);
+        }
+        return rangeValidator.isValid(value, constraintValidatorContext);
+    }
+
+    private void assertInvalidAnnotation(Object value) {
+        Assertions.assertThrows(IllegalStateException.class, () -> this.validate(value));
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate")
+    private static class DateRangeDefaults {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", nullHandling = DateRange.NullHandling.AT_LEAST_ONE_MUST_BE_NONNULL)
+    private static class DateRangeAtLeastOne {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class DateRangeNotEqual {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class MissingEndDate {
+        private final LocalDate startDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class ConflictingFieldTypes {
+        private final LocalDate startDate;
+        private final ZonedDateTime endDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class ConflictingMethodTypes {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+
+        // start date uses LocalDate via @Data
+        @SuppressWarnings("unused")
+        public ZonedDateTime getEndDate() {
+            return null;
+        }
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class ConflictingFieldVsMethodTypes {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+
+        @SuppressWarnings("unused")
+        public ZonedDateTime getStartDate() {
+            return null;
+        }
+
+        @SuppressWarnings("unused")
+        public ZonedDateTime getEndDate() {
+            return null;
+        }
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate", equalHandling = DateRange.EqualHandling.EQUAL_INVALID)
+    private static class NotDeclaredAsTemporal {
+        private final Object startDate;
+        private final Object endDate;
+    }
+
+    @Data(staticConstructor = "of")
+    @DateRange(startField = "startDate", endField = "endDate")
+    private static class GetterThrowsException {
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+
+        @SuppressWarnings("unused")
+        public LocalDate getEndDate() {
+            throw new RuntimeException("Boom!");
+        }
+    }
+}


### PR DESCRIPTION
Expected to be used via:

```java

@Data
@DateRange(startField = "earliestExpectedArrivalDate", endField = "latestExpectedArrivalDate", nullHandling = NullHandling.AT_LEAST_ONE_MUST_BE_NONNULL)
public class MyEntity {

    private LocalDate earliestExpectedArrivalDate;

    private LocalDate latestExpectedArrivalDate;
}

```

This validation would ensure that at least one of the fields will be
not-null and, if they are both present, then the earliest field is
lower than or equal to the latest field.

Signed-off-by: Niels Thykier <nt@asseco.dk>