### PR TITLE
DDT-861: Provide comma-separated list parsing of query params

### DIFF
--- a/src/main/java/org/dcsa/core/extendedrequest/ComparisonType.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/ComparisonType.java
@@ -32,14 +32,8 @@ enum ComparisonType {
     }
 
     public Expression defaultFieldConversion(QueryField queryField) {
-        boolean needsCast = convertToString;
-        if (needsCast) {
-            Class<?> valueType = queryField.getType();
-            if (valueType.isEnum() || String.class.equals(valueType)) {
-                needsCast = false;
-            }
-        }
-        if (needsCast) {
+        Class<?> valueType = queryField.getType();
+        if (convertToString && !(valueType.isEnum() || String.class.equals(valueType))) {
             Column aliased = queryField.getInternalQueryColumn().as(SqlIdentifier.unquoted("VARCHAR"));
             return SimpleFunction.create("CAST", Collections.singletonList(aliased));
         }

--- a/src/main/java/org/dcsa/core/extendedrequest/ComparisonType.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/ComparisonType.java
@@ -1,0 +1,79 @@
+package org.dcsa.core.extendedrequest;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.relational.core.sql.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+enum ComparisonType {
+    GT(true, Conditions::isGreater),
+    GTE(true, Conditions::isGreaterOrEqualTo),
+    EQ(false, Conditions::isEqual),
+    LTE(true, Conditions::isLessOrEqualTo),
+    LT(true, Conditions::isLess),
+    NEQ(false, Conditions::isNotEqual),
+    SUBSTR(false, Conditions::like),
+    IEQ(false, true, QueryParameterParser::iequal),
+    ISUBSTR(false, true, QueryParameterParser::isubstr),
+    ;
+
+    private final boolean requiredOrdering;
+    private final boolean convertToString;
+    private final BiFunction<Expression, Expression, FilterCondition> singleValueConverter;
+
+    ComparisonType(boolean requiredOrdering, BiFunction<Expression, Expression, Condition> conditionBiFunction) {
+        this(requiredOrdering, false, (lhs, rhs) -> QueryParameterParser.InlineableFilterCondition.of(conditionBiFunction.apply(lhs, rhs)));
+    }
+
+    public Expression defaultFieldConversion(QueryField queryField) {
+        boolean needsCast = convertToString;
+        if (needsCast) {
+            Class<?> valueType = queryField.getType();
+            if (valueType.isEnum() || String.class.equals(valueType)) {
+                needsCast = false;
+            }
+        }
+        if (needsCast) {
+            Column aliased = queryField.getInternalQueryColumn().as(SqlIdentifier.unquoted("VARCHAR"));
+            return SimpleFunction.create("CAST", Collections.singletonList(aliased));
+        }
+        return queryField.getInternalQueryColumn();
+    }
+
+    public FilterCondition singleNonNullValueCondition(QueryField queryField, Expression expression) {
+        return singleNonNullValueCondition(defaultFieldConversion(queryField), expression);
+    }
+
+    public FilterCondition singleNonNullValueCondition(Expression field, Expression expression) {
+        return singleValueConverter.apply(field, expression);
+    }
+
+    public FilterCondition multiValueCondition(QueryField queryField, List<Expression> expressions) {
+        return multiValueCondition(defaultFieldConversion(queryField), expressions);
+    }
+
+    public FilterCondition multiValueCondition(Expression field, List<Expression> expressions) {
+        if (expressions.isEmpty()) {
+            throw new IllegalArgumentException("Right-hand side expression list must be non-empty");
+        }
+        if (expressions.size() == 1) {
+            return singleNonNullValueCondition(field, expressions.get(0));
+        } else if (this == EQ || this == NEQ) {
+            if (this == EQ) {
+                return QueryParameterParser.InlineableFilterCondition.of(Conditions.in(field, expressions));
+            }
+            return QueryParameterParser.InlineableFilterCondition.of(Conditions.notIn(field, expressions));
+        } else {
+            return QueryParameterParser.andAllFilters(
+                    expressions.stream().map(e -> singleValueConverter.apply(field, e)).collect(Collectors.toList()),
+                    true
+            );
+        }
+    }
+}

--- a/src/main/java/org/dcsa/core/extendedrequest/ExtendedParameters.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/ExtendedParameters.java
@@ -136,29 +136,6 @@ public class ExtendedParameters {
     @Value( "${enum.split:,}" )
     private String enumSplit;
 
-    // Choose how query parameter attributes are handled.  Options include:
-    //
-    // * NO_ATTRIBUTES                 - There are no attributes at all.
-    // * PARAMETER_NAME_ARRAY_NOTATION - The attribute is in the query parameter
-    //                                   name a la "name[attribute]=value"
-    // * PARAMETER_NAME_SUFFIX         - The attribute is in the query parameter
-    //                                   name a la "name:attribute=value".
-    // * PARAMETER_VALUE_PREFIX        - The attribute is a prefix of the value
-    //                                   a la "name=attribute:value".
-    //
-    // Note that attributes are parsed from the decoded parameter name or value.
-    //
-    // Attributes can be used to alter how a query parameter is interpreted and
-    // is often used for operators a la "x >= y"-operations.  However, the
-    // application can implement its own attributes.
-    //
-    // This can be changed in application.yaml file by writing:
-    // search:
-    //   queryParameterAttributeHandling: PARAMETER_VALUE_PREFIX
-    @Value("${search.queryParameterAttributeHandling:PARAMETER_NAME_SUFFIX}")
-    @Getter
-    private QueryParameterAttributeHandling queryParameterAttributeHandling;
-
     // Choose the separator for attributes embedded in the query parameters.
     // The separator is applied on the decoded value.  Whether it is used
     // for the name or the value is determined by

--- a/src/main/java/org/dcsa/core/extendedrequest/FilterConditionGenerators.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/FilterConditionGenerators.java
@@ -1,0 +1,39 @@
+package org.dcsa.core.extendedrequest;
+
+import org.dcsa.core.exception.GetException;
+import org.springframework.data.relational.core.sql.Expression;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+class FilterConditionGenerators {
+
+    static final QueryFieldConditionGenerator IN_COMMA_SEPARATED_LIST = new QueryFieldConditionGenerator() {
+        @Override
+        public FilterCondition generateCondition(QueryField queryField, ComparisonType comparisonType, String fieldAttribute, List<String> queryParamValues, Function<String, Expression> value2BindVariable) {
+            if (comparisonType != ComparisonType.EQ && comparisonType != ComparisonType.NEQ) {
+                throw new GetException("Cannot use attribute (operator) " + fieldAttribute + " on " + queryField.getJsonName()
+                        + ": The query parameter can only be used with strictly equal or not-equal relations");
+            }
+
+            List<Expression> allValues = queryParamValues.stream().flatMap(v -> Arrays.stream(v.split(",")))
+                    .peek(v -> {
+                                if ("NULL".equals(v)) {
+                                    // "X IN (NULL)" is not the same as "X IS NULL" and it is not important to support it
+                                    // right now.
+                                    // Note: This remark assumes that "NULL" is mapped to a literal SQL null rather than
+                                    // the string 'NULL'.  The assumption is to match how we handle NULL inside the
+                                    // QueryParameterParser.
+                                    throw new GetException("Support for NULL in " + queryField.getJsonName()
+                                            + " is missing.");
+                                }
+                            }
+                    ).map(value2BindVariable)
+                    .collect(Collectors.toList());
+
+            return comparisonType.multiValueCondition(queryField, allValues);
+        }
+    };
+}

--- a/src/main/java/org/dcsa/core/extendedrequest/QueryField.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/QueryField.java
@@ -1,8 +1,11 @@
 package org.dcsa.core.extendedrequest;
 
 import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.Expression;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.Function;
 
 public interface QueryField {
 
@@ -20,6 +23,49 @@ public interface QueryField {
         return null;
     }
     default Field getCombinedModelField() {
+        return null;
+    }
+
+    /**
+     * Generates the condition for this query field for a concrete request (optional operation)
+     *
+     * <p>
+     * This method will be called whenever the query field is used as a query parameter.  Note it can be called multiple
+     * times for a given request if the field attributes differ and the results will be AND'ed together.
+     * <p>
+     * The implementation should convert the input into a {@link FilterCondition} using the following over all steps:
+     *
+     * <ol>
+     *     <li>The implementation should check it is defined for the given comparison type. If not, throw an exception
+     *         that will cause an HTTP Bad Request error.</li>
+     *     <li>All values from queryParamValues that go into the query should be passed through the value2BindVariable
+     *         function to get the bind variable to insert the value there. The string value passed there must be
+     *         convertable into the underlying type of this query field.</li>
+     *     <li>The bind variable(s) from the previous step should be passed to methods like
+     *     {@link ComparisonType#singleNonNullValueCondition(QueryField, Expression)} or
+     *     {@link ComparisonType#multiValueCondition(QueryField, List)} to generate the condition</li>
+     *
+     * </ol>
+     *
+     * @param comparisonType     The comparison type used (defaults to {@link ComparisonType#EQ}). The code is not required to use this
+     *                           comparison type - it is just what the engine thought would be used in the default context.
+     *                           This generally mirrors the fieldAttribute except you cannot tell whether the choice was explicit
+     *                           or implicit.
+     *                           If the method does not support the given comparison type it should throw an exception that will
+     *                           cause an HTTP 400 Bad Request response.
+     * @param fieldAttribute     The field attribute used on the attribute (defaults to null when there is no explicit attribute).
+     *                           This uses the exact case as provided by the client.
+     * @param queryParamValues   The values passed as query parameters (as-is) for this choice of field attribute.  The code
+     *                           may preprocess the values however it likes (but it may need to copy the list to do so as
+     *                           the list itself is immutable).
+     * @param value2BindVariable A function that maps a single query parameter value into the underlying type needed in the database.
+     * @return The filterCondition that represents the SQL condition (or null, if the default generator should be used).
+     */
+    default FilterCondition generateCondition(ComparisonType comparisonType,
+                                              String fieldAttribute,
+                                              List<String> queryParamValues,
+                                              Function<String, Expression> value2BindVariable
+    ) {
         return null;
     }
 }

--- a/src/main/java/org/dcsa/core/extendedrequest/QueryFieldConditionGenerator.java
+++ b/src/main/java/org/dcsa/core/extendedrequest/QueryFieldConditionGenerator.java
@@ -1,0 +1,96 @@
+package org.dcsa.core.extendedrequest;
+
+import org.springframework.data.relational.core.sql.Expression;
+
+import org.dcsa.core.query.DBEntityAnalysis;
+
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class QueryFieldConditionGenerator {
+
+    /* package-private, the API should not be implemented outside DCSA-Core for now
+     *
+     * The API is sufficient to provide the inCommaSeparatedList feature, which is
+     * what we need for now. However, it is subpar with the QueryParameterParser.
+     * Notably the value2BindVariable parameter feels a bit "iffy", you are
+     * forced into the pre-defined set of field attributes for ComparisonType,
+     * etc.
+     *
+     * Fixing that is left for another day because we might not need that
+     * flexibility.
+     */
+    QueryFieldConditionGenerator() {}
+
+    /**
+     * Generates the condition for this query field for a concrete request
+     * <p>
+     * This method will be called whenever the query field is used as a query parameter.  Note it can be called multiple
+     * times for a given request if the field attributes differ and the results will be AND'ed together.
+     * <p>
+     * The implementation should convert the input into a {@link FilterCondition} using the following over all steps:
+     *
+     * <ol>
+     *     <li>The implementation should check it is defined for the given comparison type. If not, throw an exception
+     *         that will cause an HTTP Bad Request error.</li>
+     *     <li>All values from queryParamValues that go into the query should be passed through the value2BindVariable
+     *         function to get the bind variable to insert the value there. The string value passed there must be
+     *         convertable into the underlying type of this query field (unless the comparison type forces the type into
+     *         strings - see {@link ComparisonType#isConvertToString()})</li>
+     *     <li>The bind variable(s) from the previous step should be passed to methods like
+     *     {@link ComparisonType#singleNonNullValueCondition(QueryField, Expression)} or
+     *     {@link ComparisonType#multiValueCondition(QueryField, List)} to generate the condition</li>
+     *
+     * </ol>
+     *
+     * @param queryField         The query field this generator should generate the condition for.
+     * @param comparisonType     The comparison type used (defaults to {@link ComparisonType#EQ}). The code is not required to use this
+     *                           comparison type - it is just what the engine thought would be used in the default context.
+     *                           This generally mirrors the fieldAttribute except you cannot tell whether the choice was explicit
+     *                           or implicit.
+     *                           If the method does not support the given comparison type it should throw an exception that will
+     *                           cause an HTTP 400 Bad Request response.
+     * @param fieldAttribute     The field attribute used on the attribute (defaults to null when there is no explicit attribute).
+     *                           This uses the exact case as provided by the client.
+     * @param queryParamValues   The values passed as query parameters (as-is) for this choice of field attribute.  The code
+     *                           may preprocess the values however it likes (but it may need to copy the list to do so as
+     *                           the list itself is immutable).
+     * @param value2BindVariable A function that maps a single query parameter value into the underlying type needed in the database.
+     * @return The filterCondition that represents the SQL condition.
+     */
+    public abstract FilterCondition generateCondition(QueryField queryField,
+                                                      ComparisonType comparisonType,
+                                                      String fieldAttribute,
+                                                      List<String> queryParamValues,
+                                                      Function<String, Expression> value2BindVariable
+    );
+
+    /**
+     * QueryFieldConditionGenerator that treats the Query field as a comma separated list
+     *
+     * The resulting QueryFieldConditionGenerator will treat the QueryField as a
+     * comma-separated list of values.  The values will be used to generate the
+     * equivalent of a "X IN (LIST)"-clause (or "X NOT IN (LIST)" if the ":neq"
+     * attribute is used).  As an example, given the query parameter is:
+     *
+     * <code>q=A,B</code>
+     *
+     * Then by using this condition generator, the query will have a WHERE
+     * clause containing:
+     *
+     * <code>q IN ('A', 'B')</code>
+     *
+     * (Literal values have been using to keep the example simple.  The
+     * actual result will rely on bind variables.)
+     *
+     * The return value can be used together with {@link DBEntityAnalysis.DBEntityAnalysisWithTableBuilder#registerQueryFieldFromField(String, QueryFieldConditionGenerator)}
+     * or similar methods to register a custom query field with this comma-list
+     * interpretation.
+     *
+     * Note that the field attributes will be restricted to ":eq", ":neq" for the
+     * query field.
+     */
+    public static QueryFieldConditionGenerator inCommaSeparatedList() {
+        return FilterConditionGenerators.IN_COMMA_SEPARATED_LIST;
+    }
+}

--- a/src/main/java/org/dcsa/core/query/DBEntityAnalysis.java
+++ b/src/main/java/org/dcsa/core/query/DBEntityAnalysis.java
@@ -2,6 +2,7 @@ package org.dcsa.core.query;
 
 import org.dcsa.core.extendedrequest.JoinDescriptor;
 import org.dcsa.core.extendedrequest.QueryField;
+import org.dcsa.core.extendedrequest.QueryFieldConditionGenerator;
 import org.dcsa.core.extendedrequest.TableAndJoins;
 import org.dcsa.core.query.impl.DefaultDBEntityAnalysisBuilder;
 import org.springframework.data.relational.core.sql.Column;
@@ -89,8 +90,14 @@ public interface DBEntityAnalysis<T> {
         DBEntityAnalysisJoinBuilder<T> chainJoin(Join.JoinType joinType, Class<?> rhsModel, String rhsJoinAlias);
         DBEntityAnalysisJoinBuilder<T> chainJoin(Join.JoinType joinType, Table rhsTable);
 
-        DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName);
-        DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType);
+        default DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName) {
+            return this.registerQueryFieldFromField(fieldName, null);
+        }
+        DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, QueryFieldConditionGenerator conditionGenerator);
+        default DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType) {
+            return this.registerQueryField(columnName, jsonName, valueType, null);
+        }
+        DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType, QueryFieldConditionGenerator conditionGenerator);
         DBEntityAnalysisBuilder<T> registerQueryFieldAlias(String jsonName, String jsonNameAlias);
 
         default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldFromFieldThen(String fieldName) {
@@ -100,6 +107,16 @@ public interface DBEntityAnalysis<T> {
 
         default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldThen(SqlIdentifier columnName, String jsonName, Class<?> valueType) {
             registerQueryField(columnName, jsonName, valueType);
+            return this;
+        }
+
+        default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldFromFieldThen(String fieldName, QueryFieldConditionGenerator conditionGenerator) {
+            registerQueryFieldFromField(fieldName, conditionGenerator);
+            return this;
+        }
+
+        default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldThen(SqlIdentifier columnName, String jsonName, Class<?> valueType, QueryFieldConditionGenerator conditionGenerator) {
+            registerQueryField(columnName, jsonName, valueType, conditionGenerator);
             return this;
         }
 

--- a/src/main/java/org/dcsa/core/query/impl/AbstractDBEntityAnalysisBuilder.java
+++ b/src/main/java/org/dcsa/core/query/impl/AbstractDBEntityAnalysisBuilder.java
@@ -2,6 +2,7 @@ package org.dcsa.core.query.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.dcsa.core.extendedrequest.JoinDescriptor;
+import org.dcsa.core.extendedrequest.QueryFieldConditionGenerator;
 import org.dcsa.core.extendedrequest.QueryFields;
 import org.dcsa.core.query.DBEntityAnalysis;
 import org.dcsa.core.util.ReflectUtility;
@@ -239,7 +240,7 @@ public abstract class AbstractDBEntityAnalysisBuilder<T> implements DBEntityAnal
             return builder.registerQueryFieldAlias(jsonName, jsonNameAlias);
         }
 
-        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName) {
+        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, QueryFieldConditionGenerator conditionGenerator) {
             Field field;
             if (lhsModel == null) {
                 throw new UnsupportedOperationException("Cannot use field based field registration as there is no model"
@@ -251,16 +252,18 @@ public abstract class AbstractDBEntityAnalysisBuilder<T> implements DBEntityAnal
                 throw new IllegalArgumentException("The model " + lhsModel.getSimpleName() + " does not have a field \""
                         + fieldName + "\"");
             }
-            return builder.registerQueryField(QueryFields.queryFieldFromField(
+            return builder.registerQueryField(QueryFields.queryFieldFromFieldWithSelectPrefix(
                     field,
                     lhsTable,
-                    false
+                    false,
+                    "",
+                    conditionGenerator
             ));
         }
 
-        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType) {
+        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType, QueryFieldConditionGenerator conditionGenerator) {
             Column column = Column.create(columnName, lhsTable);
-            return builder.registerQueryField(QueryFields.nonSelectableQueryField(column, jsonName, valueType));
+            return builder.registerQueryField(QueryFields.nonSelectableQueryField(column, jsonName, valueType, conditionGenerator));
         }
 
     }

--- a/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
+++ b/src/main/java/org/dcsa/core/query/impl/DefaultDBEntityAnalysisBuilder.java
@@ -325,7 +325,6 @@ public class DefaultDBEntityAnalysisBuilder<T> extends AbstractDBEntityAnalysisB
     }
 
     private void generatePrefixedQueryFieldsDeep(EntityTreeNode currentNode) {
-        Class<?> modelType = currentNode.getModelType();
         Table table = getTableFor(currentNode);
         String prefix = currentNode.getSelectNamePrefix();
 

--- a/src/test/java/org/dcsa/core/ExtendedRequestTest.java
+++ b/src/test/java/org/dcsa/core/ExtendedRequestTest.java
@@ -178,7 +178,14 @@ public class ExtendedRequestTest {
 
         verifierFor(requestConstructor)
                 .withParam("cn", "dk")
+                // Special-case, the underlying generator (ComparisonType.EQ) collapses an "IN" into "="
+                // when there is a single item (but it could just as well have used "IN" here).
                 .verify(baseQueryNoExtraJoins + extraJoins + " WHERE c.country_name = :cn");
+
+        verifierFor(requestConstructor)
+                .withParam("cn", "dk,en,de")
+                // The repeated ":cn" matches each value being provided.
+                .verify(baseQueryNoExtraJoins + extraJoins + " WHERE c.country_name IN (:cn, :cn, :cn)");
     }
 
 }

--- a/src/test/java/org/dcsa/core/models/CitySpecificExtendedRequest.java
+++ b/src/test/java/org/dcsa/core/models/CitySpecificExtendedRequest.java
@@ -22,6 +22,7 @@ public class CitySpecificExtendedRequest extends ExtendedRequest<City> {
         return builder
                 .join(Join.JoinType.JOIN, cityTable, countryTable, County.class)
                 .onFieldEqualsThen("countryId", "id")
-                .registerQueryField(SqlIdentifier.unquoted("country_name"), "cn", String.class);
+                .registerQueryField(SqlIdentifier.unquoted("country_name"), "cn", String.class, QueryFieldConditionGenerator.inCommaSeparatedList());
+
     }
 }


### PR DESCRIPTION
Provide a built-in way of making a custom query parameter be interpreted as comma-separated list of values (similar to how enums are treated by default).

For consumers, this new feature can be used by passing `QueryFieldConditionGenerator.inCommaSeparatedList()` as the last argument to the `registerQueryField` (et al.) methods.


Note that the PR also includes two additional commits move some code around / remove a now redundant feature in the aims of simplifying implementation of this new feature.