### PR TITLE
JsonProperty Access mapper

### DIFF
--- a/src/main/java/org/dcsa/core/repository/RowMapper.java
+++ b/src/main/java/org/dcsa/core/repository/RowMapper.java
@@ -42,7 +42,7 @@ class RowMapper {
                   A annotation = super._findAnnotation(annotated, annoClass);
 
                   if (JsonProperty.class.equals(annoClass) && ((JsonProperty) annotation).access() != JsonProperty.Access.AUTO) {
-                    annotation = MappingUtils.doStuff(annotation);
+                    annotation = MappingUtils.jsonPropertyAutoMapper(annotation);
                   }
                   return annotation;
                 }

--- a/src/main/java/org/dcsa/core/repository/RowMapper.java
+++ b/src/main/java/org/dcsa/core/repository/RowMapper.java
@@ -36,12 +36,12 @@ class RowMapper {
                 @Override
                 protected <A extends Annotation> A _findAnnotation(
                     Annotated annotated, Class<A> annoClass) {
-                  if (JsonIgnore.class.equals(annoClass) || JsonProperty.class.equals(annoClass)) {
+                  if (JsonIgnore.class.equals(annoClass)) {
                     return null;
                   }
                   A annotation = super._findAnnotation(annotated, annoClass);
 
-                  if (JsonProperty.class.equals(annoClass) && ((JsonProperty) annotation).access() != JsonProperty.Access.AUTO) {
+                  if (annotation != null && JsonProperty.class.equals(annoClass)) {
                     annotation = MappingUtils.jsonPropertyAutoMapper(annotation);
                   }
                   return annotation;

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -82,48 +82,46 @@ public class MappingUtils {
     return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
   }
 
+  @SuppressWarnings("unchecked")
   public static <A extends Annotation> A jsonPropertyAutoMapper(A annotation) {
     JsonProperty real = (JsonProperty) annotation;
-    @SuppressWarnings("unchecked")
-    A delegate =
-        (A)
-            new JsonProperty() {
-              @Override
-              public String value() {
-                return real.value();
-              }
+    return (A)
+        new JsonProperty() {
+          @Override
+          public String value() {
+            return real.value();
+          }
 
-              @Override
-              public String namespace() {
-                return real.namespace();
-              }
+          @Override
+          public String namespace() {
+            return real.namespace();
+          }
 
-              @Override
-              public boolean required() {
-                return false; // Do not force something to mandatory from the DB just
-                // because it is mandatory in the JSON
-              }
+          @Override
+          public boolean required() {
+            return false; // Do not force something to mandatory from the DB just
+            // because it is mandatory in the JSON
+          }
 
-              @Override
-              public int index() {
-                return real.index();
-              }
+          @Override
+          public int index() {
+            return real.index();
+          }
 
-              @Override
-              public String defaultValue() {
-                return real.defaultValue();
-              }
+          @Override
+          public String defaultValue() {
+            return real.defaultValue();
+          }
 
-              @Override
-              public Access access() {
-                return Access.AUTO; // We always map into that field even if it is read only
-              }
+          @Override
+          public Access access() {
+            return Access.AUTO; // We always map into that field even if it is read only
+          }
 
-              @Override
-              public Class<? extends Annotation> annotationType() {
-                return real.annotationType();
-              }
-            };
-    return delegate;
+          @Override
+          public Class<? extends Annotation> annotationType() {
+            return real.annotationType();
+          }
+        };
   }
 }

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -14,114 +14,115 @@ import java.util.function.Supplier;
 
 public class MappingUtils {
 
-  /* For use with ".buffer(...).concatMap(service::createOrUpdateOrDeleteAll), etc. where the underlying
-   * operation uses a variant "WHERE foo IN (LIST)".
-   *
-   * A higher number means fewer queries but after a certain size postgres performance will degrade.
-   * Plus a higher number will also require more memory (java-side) as we build up a list of items.
-   *
-   * The number should be sufficient to bundle most trivial things into a single query without hitting
-   * performance issues.
-   */
-  public static final int SQL_LIST_BUFFER_SIZE = 70;
+    /* For use with ".buffer(...).concatMap(service::createOrUpdateOrDeleteAll), etc. where the underlying
+     * operation uses a variant "WHERE foo IN (LIST)".
+     *
+     * A higher number means fewer queries but after a certain size postgres performance will degrade.
+     * Plus a higher number will also require more memory (java-side) as we build up a list of items.
+     *
+     * The number should be sufficient to bundle most trivial things into a single query without hitting
+     * performance issues.
+     */
+    public static final int SQL_LIST_BUFFER_SIZE = 70;
 
-  /** Use Mappers instead. */
-  @Deprecated
-  public static <C, S extends C, T extends C> T instanceFrom(
-      S source, Supplier<T> targetConstructor, Class<C> clazz) {
-    T target = targetConstructor.get();
-    copyFields(source, target, clazz);
-    return target;
-  }
+    /**
+     * Use Mappers instead.
+     */
+    @Deprecated
+    public static <C, S extends C, T extends C> T instanceFrom(S source, Supplier<T> targetConstructor, Class<C> clazz) {
+        T target = targetConstructor.get();
+        copyFields(source, target, clazz);
+        return target;
+    }
 
-  /** Use Mappers instead. */
-  @Deprecated
-  @SneakyThrows({InvocationTargetException.class, IllegalAccessException.class})
-  public static <C, S extends C, T extends C> void copyFields(S source, T target, Class<C> clazz) {
-    /* Only clone the abstract fields that we know they share */
-    Class<?> currentClass = clazz;
-    Set<String> seenFields = new HashSet<>();
-    while (currentClass != Object.class) {
-      for (Field field : currentClass.getDeclaredFields()) {
-        if (field.isSynthetic()) {
-          continue;
+    /**
+     * Use Mappers instead.
+     */
+    @Deprecated
+    @SneakyThrows({InvocationTargetException.class, IllegalAccessException.class})
+    public static <C, S extends C, T extends C> void copyFields(S source, T target, Class<C> clazz) {
+        /* Only clone the abstract fields that we know they share */
+        Class<?> currentClass = clazz;
+        Set<String> seenFields = new HashSet<>();
+        while (currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if (field.isSynthetic()) {
+                    continue;
+                }
+                String fieldName = field.getName();
+                Object value;
+                /* skip fields that have already been seen in a subclass */
+                if (!seenFields.add(fieldName)) {
+                    continue;
+                }
+                if (field.isAnnotationPresent(Transient.class)) {
+                    continue;
+                }
+                value = getFieldValue(source, field, currentClass);
+                try {
+                    field.set(target, value);
+                } catch (IllegalAccessException e) {
+                    ReflectUtility.setValueUsingMethod(target, currentClass, fieldName, field.getType(), value);
+                }
+            }
+            currentClass = currentClass.getSuperclass();
         }
-        String fieldName = field.getName();
-        Object value;
-        /* skip fields that have already been seen in a subclass */
-        if (!seenFields.add(fieldName)) {
-          continue;
-        }
-        if (field.isAnnotationPresent(Transient.class)) {
-          continue;
-        }
-        value = getFieldValue(source, field, currentClass);
+    }
+
+    private static Object getFieldValue(Object source, Field field, Class<?> declaringClass) throws InvocationTargetException, IllegalAccessException {
         try {
-          field.set(target, value);
+            return field.get(source);
         } catch (IllegalAccessException e) {
-          ReflectUtility.setValueUsingMethod(
-              target, currentClass, fieldName, field.getType(), value);
+            Method getterMethod = getGetMethod(declaringClass, field.getName());
+            return getterMethod.invoke(source);
         }
-      }
-      currentClass = currentClass.getSuperclass();
     }
-  }
 
-  private static Object getFieldValue(Object source, Field field, Class<?> declaringClass)
-      throws InvocationTargetException, IllegalAccessException {
-    try {
-      return field.get(source);
-    } catch (IllegalAccessException e) {
-      Method getterMethod = getGetMethod(declaringClass, field.getName());
-      return getterMethod.invoke(source);
+    private static Method getGetMethod(Class<?> clazz, String fieldName) {
+        String capitalizedFieldName = ReflectUtility.capitalize(fieldName);
+        return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
     }
-  }
-
-  private static Method getGetMethod(Class<?> clazz, String fieldName) {
-    String capitalizedFieldName = ReflectUtility.capitalize(fieldName);
-    return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
-  }
 
   @SuppressWarnings("unchecked")
   public static <A extends Annotation> A jsonPropertyAutoMapper(A annotation) {
     JsonProperty real = (JsonProperty) annotation;
     return (A)
-        new JsonProperty() {
-          @Override
-          public String value() {
-            return real.value();
-          }
+      new JsonProperty() {
+        @Override
+        public String value() {
+          return real.value();
+        }
 
-          @Override
-          public String namespace() {
-            return real.namespace();
-          }
+        @Override
+        public String namespace() {
+          return real.namespace();
+        }
 
-          @Override
-          public boolean required() {
-            return false; // Do not force something to mandatory from the DB just
-            // because it is mandatory in the JSON
-          }
+        @Override
+        public boolean required() {
+          return false; // Do not force something to mandatory from the DB just
+          // because it is mandatory in the JSON
+        }
 
-          @Override
-          public int index() {
-            return real.index();
-          }
+        @Override
+        public int index() {
+          return real.index();
+        }
 
-          @Override
-          public String defaultValue() {
-            return real.defaultValue();
-          }
+        @Override
+        public String defaultValue() {
+          return real.defaultValue();
+        }
 
-          @Override
-          public Access access() {
-            return Access.AUTO; // We always map into that field even if it is read only
-          }
+        @Override
+        public Access access() {
+          return Access.AUTO; // We always map into that field even if it is read only
+        }
 
-          @Override
-          public Class<? extends Annotation> annotationType() {
-            return real.annotationType();
-          }
-        };
+        @Override
+        public Class<? extends Annotation> annotationType() {
+          return real.annotationType();
+        }
+      };
   }
 }

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -82,7 +82,7 @@ public class MappingUtils {
     return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
   }
 
-  public static <A extends Annotation> A doStuff(A annotation) {
+  public static <A extends Annotation> A jsonPropertyAutoMapper(A annotation) {
     JsonProperty real = (JsonProperty) annotation;
     @SuppressWarnings("unchecked")
     A delegate =

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -1,8 +1,10 @@
 package org.dcsa.core.util;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.SneakyThrows;
 import org.springframework.data.annotation.Transient;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -12,72 +14,116 @@ import java.util.function.Supplier;
 
 public class MappingUtils {
 
-    /* For use with ".buffer(...).concatMap(service::createOrUpdateOrDeleteAll), etc. where the underlying
-     * operation uses a variant "WHERE foo IN (LIST)".
-     *
-     * A higher number means fewer queries but after a certain size postgres performance will degrade.
-     * Plus a higher number will also require more memory (java-side) as we build up a list of items.
-     *
-     * The number should be sufficient to bundle most trivial things into a single query without hitting
-     * performance issues.
-     */
-    public static final int SQL_LIST_BUFFER_SIZE = 70;
+  /* For use with ".buffer(...).concatMap(service::createOrUpdateOrDeleteAll), etc. where the underlying
+   * operation uses a variant "WHERE foo IN (LIST)".
+   *
+   * A higher number means fewer queries but after a certain size postgres performance will degrade.
+   * Plus a higher number will also require more memory (java-side) as we build up a list of items.
+   *
+   * The number should be sufficient to bundle most trivial things into a single query without hitting
+   * performance issues.
+   */
+  public static final int SQL_LIST_BUFFER_SIZE = 70;
 
-    /**
-     * Use Mappers instead.
-     */
-    @Deprecated
-    public static <C, S extends C, T extends C> T instanceFrom(S source, Supplier<T> targetConstructor, Class<C> clazz) {
-        T target = targetConstructor.get();
-        copyFields(source, target, clazz);
-        return target;
-    }
+  /** Use Mappers instead. */
+  @Deprecated
+  public static <C, S extends C, T extends C> T instanceFrom(
+      S source, Supplier<T> targetConstructor, Class<C> clazz) {
+    T target = targetConstructor.get();
+    copyFields(source, target, clazz);
+    return target;
+  }
 
-    /**
-     * Use Mappers instead.
-     */
-    @Deprecated
-    @SneakyThrows({InvocationTargetException.class, IllegalAccessException.class})
-    public static <C, S extends C, T extends C> void copyFields(S source, T target, Class<C> clazz) {
-        /* Only clone the abstract fields that we know they share */
-        Class<?> currentClass = clazz;
-        Set<String> seenFields = new HashSet<>();
-        while (currentClass != Object.class) {
-            for (Field field : currentClass.getDeclaredFields()) {
-                if (field.isSynthetic()) {
-                    continue;
-                }
-                String fieldName = field.getName();
-                Object value;
-                /* skip fields that have already been seen in a subclass */
-                if (!seenFields.add(fieldName)) {
-                    continue;
-                }
-                if (field.isAnnotationPresent(Transient.class)) {
-                    continue;
-                }
-                value = getFieldValue(source, field, currentClass);
-                try {
-                    field.set(target, value);
-                } catch (IllegalAccessException e) {
-                    ReflectUtility.setValueUsingMethod(target, currentClass, fieldName, field.getType(), value);
-                }
-            }
-            currentClass = currentClass.getSuperclass();
+  /** Use Mappers instead. */
+  @Deprecated
+  @SneakyThrows({InvocationTargetException.class, IllegalAccessException.class})
+  public static <C, S extends C, T extends C> void copyFields(S source, T target, Class<C> clazz) {
+    /* Only clone the abstract fields that we know they share */
+    Class<?> currentClass = clazz;
+    Set<String> seenFields = new HashSet<>();
+    while (currentClass != Object.class) {
+      for (Field field : currentClass.getDeclaredFields()) {
+        if (field.isSynthetic()) {
+          continue;
         }
-    }
-
-    private static Object getFieldValue(Object source, Field field, Class<?> declaringClass) throws InvocationTargetException, IllegalAccessException {
+        String fieldName = field.getName();
+        Object value;
+        /* skip fields that have already been seen in a subclass */
+        if (!seenFields.add(fieldName)) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Transient.class)) {
+          continue;
+        }
+        value = getFieldValue(source, field, currentClass);
         try {
-            return field.get(source);
+          field.set(target, value);
         } catch (IllegalAccessException e) {
-            Method getterMethod = getGetMethod(declaringClass, field.getName());
-            return getterMethod.invoke(source);
+          ReflectUtility.setValueUsingMethod(
+              target, currentClass, fieldName, field.getType(), value);
         }
+      }
+      currentClass = currentClass.getSuperclass();
     }
+  }
 
-    private static Method getGetMethod(Class<?> clazz, String fieldName) {
-        String capitalizedFieldName = ReflectUtility.capitalize(fieldName);
-        return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
+  private static Object getFieldValue(Object source, Field field, Class<?> declaringClass)
+      throws InvocationTargetException, IllegalAccessException {
+    try {
+      return field.get(source);
+    } catch (IllegalAccessException e) {
+      Method getterMethod = getGetMethod(declaringClass, field.getName());
+      return getterMethod.invoke(source);
     }
+  }
+
+  private static Method getGetMethod(Class<?> clazz, String fieldName) {
+    String capitalizedFieldName = ReflectUtility.capitalize(fieldName);
+    return ReflectUtility.getMethod(clazz, "get" + capitalizedFieldName);
+  }
+
+  public static <A extends Annotation> A doStuff(A annotation) {
+    JsonProperty real = (JsonProperty) annotation;
+    @SuppressWarnings("unchecked")
+    A delegate =
+        (A)
+            new JsonProperty() {
+              @Override
+              public String value() {
+                return real.value();
+              }
+
+              @Override
+              public String namespace() {
+                return real.namespace();
+              }
+
+              @Override
+              public boolean required() {
+                return false; // Do not force something to mandatory from the DB just
+                // because it is mandatory in the JSON
+              }
+
+              @Override
+              public int index() {
+                return real.index();
+              }
+
+              @Override
+              public String defaultValue() {
+                return real.defaultValue();
+              }
+
+              @Override
+              public Access access() {
+                return Access.AUTO; // We always map into that field even if it is read only
+              }
+
+              @Override
+              public Class<? extends Annotation> annotationType() {
+                return real.annotationType();
+              }
+            };
+    return delegate;
+  }
 }

--- a/src/main/java/org/dcsa/core/util/MappingUtils.java
+++ b/src/main/java/org/dcsa/core/util/MappingUtils.java
@@ -87,42 +87,42 @@ public class MappingUtils {
   public static <A extends Annotation> A jsonPropertyAutoMapper(A annotation) {
     JsonProperty real = (JsonProperty) annotation;
     return (A)
-      new JsonProperty() {
-        @Override
-        public String value() {
-          return real.value();
-        }
+        new JsonProperty() {
+          @Override
+          public String value() {
+            return real.value();
+          }
 
-        @Override
-        public String namespace() {
-          return real.namespace();
-        }
+          @Override
+          public String namespace() {
+            return real.namespace();
+          }
 
-        @Override
-        public boolean required() {
-          return false; // Do not force something to mandatory from the DB just
-          // because it is mandatory in the JSON
-        }
+          @Override
+          public boolean required() {
+            return false; // Do not force something to mandatory from the DB just
+            // because it is mandatory in the JSON
+          }
 
-        @Override
-        public int index() {
-          return real.index();
-        }
+          @Override
+          public int index() {
+            return real.index();
+          }
 
-        @Override
-        public String defaultValue() {
-          return real.defaultValue();
-        }
+          @Override
+          public String defaultValue() {
+            return real.defaultValue();
+          }
 
-        @Override
-        public Access access() {
-          return Access.AUTO; // We always map into that field even if it is read only
-        }
+          @Override
+          public Access access() {
+            return Access.AUTO; // We always map into that field even if it is read only
+          }
 
-        @Override
-        public Class<? extends Annotation> annotationType() {
-          return real.annotationType();
-        }
-      };
+          @Override
+          public Class<? extends Annotation> annotationType() {
+            return real.annotationType();
+          }
+        };
   }
 }


### PR DESCRIPTION
Niels wrote the code (excluding the white-space changes)...

Solves the problem of the Core `findAll` framework dismissing objects with `JsonProperty.Access` annotation.