### PR TITLE
DDT-1004: DBEntityBuilder: Support adding prefixed query fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<revision>0.8.31</revision>
+		<revision>0.8.32</revision>
 		<apache.commons.version>3.12.0</apache.commons.version>
 		<apache.commons.codec.version>1.15</apache.commons.codec.version>
 		<sha1/>

--- a/src/main/java/org/dcsa/core/query/DBEntityAnalysis.java
+++ b/src/main/java/org/dcsa/core/query/DBEntityAnalysis.java
@@ -103,7 +103,10 @@ public interface DBEntityAnalysis<T> {
         default DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName) {
             return this.registerQueryFieldFromField(fieldName, null);
         }
-        DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, QueryFieldConditionGenerator conditionGenerator);
+        default DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, QueryFieldConditionGenerator conditionGenerator) {
+          return registerQueryFieldFromField(fieldName, "", conditionGenerator);
+        }
+        DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, String jsonPrefix, QueryFieldConditionGenerator conditionGenerator);
         default DBEntityAnalysisBuilder<T> registerQueryField(SqlIdentifier columnName, String jsonName, Class<?> valueType) {
             return this.registerQueryField(columnName, jsonName, valueType, null);
         }
@@ -113,6 +116,11 @@ public interface DBEntityAnalysis<T> {
         default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldFromFieldThen(String fieldName) {
             registerQueryFieldFromField(fieldName);
             return this;
+        }
+
+        default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldFromFieldThen(String fieldName, String jsonPrefix) {
+          registerQueryFieldFromField(fieldName, jsonPrefix, null);
+          return this;
         }
 
         default DBEntityAnalysisWithTableBuilder<T> registerQueryFieldThen(SqlIdentifier columnName, String jsonName, Class<?> valueType) {

--- a/src/main/java/org/dcsa/core/query/impl/AbstractDBEntityAnalysisBuilder.java
+++ b/src/main/java/org/dcsa/core/query/impl/AbstractDBEntityAnalysisBuilder.java
@@ -285,7 +285,7 @@ public abstract class AbstractDBEntityAnalysisBuilder<T> implements DBEntityAnal
             return builder.registerQueryFieldAlias(jsonName, jsonNameAlias);
         }
 
-        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, QueryFieldConditionGenerator conditionGenerator) {
+        public DBEntityAnalysis.DBEntityAnalysisBuilder<T> registerQueryFieldFromField(String fieldName, String jsonPrefix, QueryFieldConditionGenerator conditionGenerator) {
             Field field;
             if (lhsModel == null) {
                 throw new UnsupportedOperationException("Cannot use field based field registration as there is no model"
@@ -301,7 +301,7 @@ public abstract class AbstractDBEntityAnalysisBuilder<T> implements DBEntityAnal
                     field,
                     lhsTable,
                     false,
-                    "",
+                    jsonPrefix,
                     conditionGenerator
             ));
         }


### PR DESCRIPTION
This is very useful for supporting import and export voyage numbers as
query parameters (as well as other things requiring join aliases
because the same table is joined twice).

Signed-off-by: Niels Thykier <nt@asseco.dk>